### PR TITLE
#56304 TimestampingBehavior fuer Massenupdates

### DIFF
--- a/Behaviors/TimeStampingBehavior.php
+++ b/Behaviors/TimeStampingBehavior.php
@@ -6,6 +6,7 @@ use exface\Core\Events\DataSheetEvent;
 use exface\Core\Exceptions\MetaModelBehaviorException;
 use exface\Core\Interfaces\Actions\iUndoActions;
 use exface\Core\Exceptions\TimeStampingBehaviorError;
+use exface\Core\CommonLogic\DataSheets\DataColumn;
 
 class TimeStampingBehavior extends AbstractBehavior {
 	private $created_on_attribute_alias = null;
@@ -91,6 +92,7 @@ class TimeStampingBehavior extends AbstractBehavior {
 		if (!$updated_column){
 			throw new MetaModelBehaviorException('Cannot check for potential update conflicts in TimeStamping behavior: column "' . $this->get_updated_on_attribute_alias() . '" not found in given data sheet!');
 		}
+		$update_nr = count($updated_column->get_values());
 		
 		$conflict_rows = array();
 		// See, if the UndoAction is performed currently. It needs special treatment
@@ -105,30 +107,62 @@ class TimeStampingBehavior extends AbstractBehavior {
 			// Check the current update timestamp in the data source
 			$check_sheet = $data_sheet->copy()->remove_rows();
 			$check_sheet->add_filter_from_column_values($data_sheet->get_uid_column());
-			//$check_sheet->get_aggregators()->add_from_string($check_sheet->get_meta_object()->get_uid_alias());
 			$check_sheet->data_read();
+			
 			$check_column = $check_sheet->get_columns()->get_by_attribute($this->get_updated_on_attribute());
-			foreach ($updated_column->get_values() as $row_nr => $val){
-				$check_val = $check_column->get_cell_value($check_sheet->get_uid_column()->find_row_by_value($data_sheet->get_uid_column()->get_cell_value($row_nr)));
+			$check_nr = count($check_column->get_values());
+			
+			if ($check_nr == $update_nr) {
+				//beim Bearbeiten eines einzelnen Objektes ueber einfaches Bearbeiten, Massenupdate in Tabelle, Massenupdate
+				//	ueber Knopf $check_nr == 1, $update_nr == 1
+				//beim Bearbeiten mehrerer Objekte ueber Massenupdate in Tabelle $check_nr == $update_nr > 1
+				foreach ($updated_column->get_values() as $row_nr => $updated_val){
+					$check_val = $check_column->get_cell_value($check_sheet->get_uid_column()->find_row_by_value($data_sheet->get_uid_column()->get_cell_value($row_nr)));
+					try {
+						$updated_date = new \DateTime($updated_val);
+						$check_date = new \DateTime($check_val);
+						/* FIXME These commented out lines were a workaround for a problem of oracle SQL delivering an other date format by default
+						 * (with milliseconds). This would cause the Check to fail, if the attribute with the timestamp had a formatter. The
+						 * formatter would change the timestamp in the GUI, thus the comparison would naturally fail. This should not be
+						 * neccessary as long as timestamping attributes do not use formatters. The lines should be removed after some testing.
+						 $format = $this->get_workbench()->get_config()->get_option('DEFAULT_DATETIME_FORMAT');
+						 $v_date = new \DateTime($val);
+						 $val_date = new \DateTime($v_date->format($format));
+						 $c_date = new \DateTime($check_val);
+						 $check_date = new \DateTime($c_date->format($format));*/
+					} catch (\Exception $e){
+						$updated_date = 0;
+						$check_date = 0;
+					}
+					
+					if ($updated_date != $check_date){
+						$conflict_rows[] = $row_nr;
+					}
+				}
+				
+			} else if ($check_nr > 1 && $update_nr == 1) {
+				//beim Bearbeiten mehrerer Objekte ueber Massenupdate ueber Knopf, Massenupdate ueber Knopf mit Filtern
+				//	$check_nr > 1, $update_nr == 1
+				$updated_val = $updated_column->get_values()[0];
+				$check_val = DataColumn::aggregate_values($check_column->get_values(), $check_column->get_attribute()->get_default_aggregate_function());
+				
 				try {
-					$val_date = new \DateTime($val);
+					if (empty($data_sheet->get_uid_column()->get_values()[0])) {
+						//Beim Massenupdate mit Filtern wird als TS_UPDATE-Wert die momentane Zeit mitgeliefert, die natuerlich neuer
+						//ist, als alle Werte in der Datenbank. Es werden jedoch keine oid-Werte uebergeben, da nicht klar ist welche
+						//Objekte betroffen sind. Momentan wird daher das Update einfach gestattet, später soll hier eine Warnung
+						//ausgegeben werden.
+						throw new \Exception('Allow mass-updates with filters.');
+					}
+					$updated_date = new \DateTime($updated_val);
 					$check_date = new \DateTime($check_val);
-					/* FIXME These commented out lines were a workaround for a problem of oracle SQL delivering an other date format by default
-					 * (with milliseconds). This would cause the Check to fail, if the attribute with the timestamp had a formatter. The 
-					 * formatter would change the timestamp in the GUI, thus the comparison would naturally fail. This should not be
-					 * neccessary as long as timestamping attributes do not use formatters. The lines should be removed after some testing.
-					$format = $this->get_workbench()->get_config()->get_option('DEFAULT_DATETIME_FORMAT');
-					$v_date = new \DateTime($val);
-					$val_date = new \DateTime($v_date->format($format));
-					$c_date = new \DateTime($check_val);
-					$check_date = new \DateTime($c_date->format($format));*/
 				} catch (\Exception $e){
-					$val_date = 0;
+					$updated_date = 0;
 					$check_date = 0;
 				}
 				
-				if ($val_date != $check_date){
-					$conflict_rows[] = $row_nr;
+				if ($updated_date != $check_date){
+					$conflict_rows = array_keys($check_column->get_values(), $check_val);
 				}
 			}
 		}

--- a/Behaviors/TimeStampingBehavior.php
+++ b/Behaviors/TimeStampingBehavior.php
@@ -6,6 +6,7 @@ use exface\Core\Events\DataSheetEvent;
 use exface\Core\Exceptions\MetaModelBehaviorException;
 use exface\Core\Interfaces\Actions\iUndoActions;
 use exface\Core\Exceptions\TimeStampingBehaviorError;
+use exface\Core\Exceptions\TimeStampingMassupdateException;
 use exface\Core\CommonLogic\DataSheets\DataColumn;
 
 class TimeStampingBehavior extends AbstractBehavior {
@@ -152,7 +153,7 @@ class TimeStampingBehavior extends AbstractBehavior {
 						//ist, als alle Werte in der Datenbank. Es werden jedoch keine oid-Werte uebergeben, da nicht klar ist welche
 						//Objekte betroffen sind. Momentan wird daher das Update einfach gestattet, später soll hier eine Warnung
 						//ausgegeben werden.
-						throw new \Exception('Allow mass-updates with filters.');
+						throw new TimeStampingMassupdateException('Allow mass-updates with filters.');
 					}
 					$updated_date = new \DateTime($updated_val);
 					$check_date = new \DateTime($check_val);

--- a/Exceptions/TimeStampingMassupdateException.php
+++ b/Exceptions/TimeStampingMassupdateException.php
@@ -1,0 +1,8 @@
+<?php namespace exface\Core\Exceptions;
+
+use exface\Core\Exceptions\MetaModelBehaviorException;
+
+class TimeStampingMassupdateException extends MetaModelBehaviorException {
+
+}
+?>


### PR DESCRIPTION
Wurde angepasst und ermoeglicht jetzt sowohl die Ueberpruefung von
Werten in mehreren Zeilen, als auch wenn noetig eines einzelnen
Wertes ueber eine Aggregation.