### PR TITLE
Issue 56308

### DIFF
--- a/Formulas/Alexastate.php
+++ b/Formulas/Alexastate.php
@@ -9,9 +9,11 @@ class alexastate extends \exface\Core\CommonLogic\Model\Formula {
 
 	function run($state, $substate, $object){
 		if (!$state) return '';
-		$return = '<div style="width:90px;border:1px solid #ccc;position:relative;color:transparent;white-space:nowrap;overflow:hidden;">' . $this->get_state_description($state, $substate, $object) .
-			'<div style="position:absolute; left:0; top:0; z-index:100; width:' . ($state ? $state / 99 * 100 : 0) . '%;' . $this->get_style($state, $substate, $object) . '">&nbsp;</div>' .
-			'<div style="position:absolute; left:0; top:0; z-index:101; color:black; width:100%; white-space:nowrap; overflow:hidden;">' . $this->get_state_description($state, $substate, $object) . '</div>' .
+		$return = '<div style="width:100%; padding:0 10px 0 10px;">' .
+			'<div style="width:100%; border:1px solid #ccc; position:relative; color:transparent; white-space:nowrap; overflow:hidden;">' . $this->get_state_description($state, $substate, $object) .
+				'<div style="position:absolute; left:0; top:0; z-index:100; width:' . ($state ? $state / 99 * 100 : 0) . '%;' . $this->get_style($state, $substate, $object) . '">&nbsp;</div>' .
+				'<div style="position:absolute; left:0; top:0; z-index:101; color:black; width:100%; white-space:nowrap; overflow:hidden;">' . $this->get_state_description($state, $substate, $object) . '</div>' .
+			'</div>' .
 		'</div>';
 		return $return;
 	}

--- a/Formulas/Today.php
+++ b/Formulas/Today.php
@@ -2,10 +2,10 @@
 
 class Today extends \exface\Core\CommonLogic\Model\Formula {
 	
-	function run(){
+	function run($format=''){
 		$exface = $this->get_workbench();
 		if (!$format) $format = $exface->get_config()->get_option('DEFAULT_DATE_FORMAT');
-		$date = new \DateTime($date);
+		$date = new \DateTime();
 		return $date->format($format);
 	}
 }

--- a/Widgets/AbstractWidget.php
+++ b/Widgets/AbstractWidget.php
@@ -39,7 +39,6 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 	private $disabled = NULL;
 	private $width = null;
 	private $height = null;
-	private $hidden = false;
 	private $visibility = null;
 	/** @var \exface\Core\Widgets\AbstractWidget the parent widget */
 	private $parent = null;
@@ -115,12 +114,13 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 	 */
 	public final function prefill(DataSheetInterface $data_sheet){
 		$this->get_workbench()->event_manager()->dispatch(EventFactory::create_widget_event($this, 'Prefill.Before'));
+		$this->set_prefill_data($data_sheet);
 		$this->do_prefill($data_sheet);
 		$this->get_workbench()->event_manager()->dispatch(EventFactory::create_widget_event($this, 'Prefill.After'));
 	}
 	
 	protected function do_prefill(DataSheetInterface $data_sheet){
-		$this->set_prefill_data($data_sheet);
+		return;
 	}
 	
 	/**
@@ -723,11 +723,13 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 	 * @see \exface\Core\Interfaces\WidgetInterface::is_hidden()
 	 */
 	public function is_hidden() {
-		return $this->hidden;
+		return $this->get_visibility() == EXF_WIDGET_VISIBILITY_HIDDEN ? true : false;
 	}
 	
 	/**
-	 * Set to TRUE to hide the widget. The same effect can be achieved by setting "visibility: hidden"
+	 * Set to TRUE to hide the widget. The same effect can be achieved by setting "visibility: hidden".
+	 * 
+	 * Setting "hidden: false" will revert visibility to normal - just like "visibility: normal".
 	 * 
 	 * @uxon-property hidden
 	 * @uxon-type boolean 
@@ -736,9 +738,10 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 	 * @see \exface\Core\Interfaces\WidgetInterface::set_hidden()
 	 */
 	public function set_hidden($value) {
-		$this->hidden = $value;
-		if ($value == true && $this->get_visibility() != EXF_WIDGET_VISIBILITY_HIDDEN){
+		if ($value){
 			$this->set_visibility(EXF_WIDGET_VISIBILITY_HIDDEN);
+		} else {
+			$this->set_visibility(EXF_WIDGET_VISIBILITY_NORMAL);
 		}
 	}	
 	
@@ -762,6 +765,7 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 	 * @see \exface\Core\Interfaces\WidgetInterface::set_visibility()
 	 */
 	public function set_visibility($value) {
+		$value = mb_strtolower($value);
 		if ($value != EXF_WIDGET_VISIBILITY_HIDDEN
 		&& $value != EXF_WIDGET_VISIBILITY_NORMAL
 		&& $value != EXF_WIDGET_VISIBILITY_OPTIONAL
@@ -770,12 +774,7 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 			return;
 		}
 		$this->visibility = $value;
-		
-		if ($value == EXF_WIDGET_VISIBILITY_HIDDEN && !$this->is_hidden()){
-			$this->set_hidden(true);
-		} else {
-			$this->set_hidden(false);
-		}
+		return $this;
 	}
 	
 	/**
@@ -896,7 +895,7 @@ abstract class AbstractWidget implements WidgetInterface, iHaveChildren {
 	/**
 	 * 
 	 * {@inheritDoc}
-	 * @see \exface\Core\Interfaces\ExfaceClassInterface::exface()
+	 * @see \exface\Core\Interfaces\ExfaceClassInterface::get_workbench()
 	 */
 	public function get_workbench(){
 		return $this->get_page()->get_workbench();

--- a/Widgets/StateMenuButton.php
+++ b/Widgets/StateMenuButton.php
@@ -35,11 +35,18 @@ class StateMenuButton extends MenuButton {
 					// Die Action des StateMenuButtons wird fuer die einzelnen Buttons uebernommen.
 					// Das UxonObject wird weiter im urspruenglichen Zustand benoetigt, daher wird
 					// der Action-Alias nur temporaer gesetzt.
+					// TODO: Das UxonObject sollte besser vor der Aktion kopiert und mit der Kopie
+					// gearbeitet werden. Das Problem ist dass die referenzierten Objekte der
+					// Kopie die selben wie beim Orginal sind, daher das Orginal verändert wird
+					// wenn man mit der Kopie arbeitet.
 					if (!is_null($this->get_action_alias())) {
 						$action_alias_temp = $smb_button->action->alias;
+						$refresh_widget_link_temp = $smb_button->refresh_widget_link;
 						$smb_button->action->alias = $this->get_action_alias();
+						$smb_button->refresh_widget_link = $this->get_refresh_widget_link();
 						$button = $this->get_page()->create_widget($button_widget, $this, UxonObject::from_anything($smb_button));
 						$smb_button->action->alias = $action_alias_temp;
+						$smb_button->refresh_widget_link = $refresh_widget_link_temp;
 					} else {
 						$button = $this->get_page()->create_widget($button_widget, $this, UxonObject::from_anything($smb_button));
 					}

--- a/Widgets/Text.php
+++ b/Widgets/Text.php
@@ -22,6 +22,7 @@ class Text extends AbstractWidget implements iShowSingleAttribute, iHaveValue, i
 	private $style = null;
 	private $aggregate_function = null;
 	private $ignore_default_value = null;
+	private $empty_text = false;
 	
 	public function get_text() {
 		if (is_null($this->text)){
@@ -240,6 +241,30 @@ class Text extends AbstractWidget implements iShowSingleAttribute, iHaveValue, i
 			return DataTypeFactory::create_from_alias($exface, EXF_DATA_TYPE_STRING);
 		}
 	}	  
-	  
+	
+	/**
+	 * If false a place-holder is shown if the text is empty (determined by WIDGET.TEXT.EMPTY_TEXT)
+	 * in the translation files. If true nothing is shown. (default: false)
+	 * 
+	 * @return boolean
+	 */
+	public function get_empty_text() {
+		return $this->empty_text;
+	}
+	
+	/**
+	 * If false a place-holder is shown if the text is empty (determined by WIDGET.TEXT.EMPTY_TEXT)
+	 * in the translation files. If true nothing is shown. (default: false)
+	 * 
+	 * @uxon-property empty_text
+	 * @uxon-type boolean
+	 * 
+	 * @param boolean $value
+	 * @return \exface\Core\Widgets\Text
+	 */
+	public function set_empty_text($value) {
+		$this->empty_text = $value;
+		return $this;
+	}
 }
 ?>


### PR DESCRIPTION
AlexaState:
- Nimmt jetzt 100% der Breite minus 20px margins ein.

Today:
- Kann ein format uebergeben werden (entsprechend now()).

AbstractWidget:
- Habe ich gerade aus master reingemergt und nichts verändert, sollte also identisch zu deinem sein. Ich nehme an man sieht so viele Änderungen, weil es mit meiner letzten Version verglichen wird.

StateMenuButton:
- Übernimmt den für StateMenuButton gesetzten refresh_widget_link für die einzelnen Buttons.

Text:
- Unterstützt die Konfiguration empty_text.
