### PR TITLE
#57784 Tabellenzeile ziehbar

### DIFF
--- a/Widgets/Planogram.php
+++ b/Widgets/Planogram.php
@@ -7,7 +7,16 @@
  *
  */
 class Planogram extends Diagram {
-	  
+	private $add_row_link_button_id = null;
+	
+	public function get_add_row_link_button_id() {
+		return $this->add_row_link_button_id;
+	}
+	
+	public function set_add_row_link_button_id($value) {
+		$this->add_row_link_button_id = $value;
+		return $this;
+	}
 }
 
 ?>


### PR DESCRIPTION
Planogram:
- Es wurde eine Verknüpfung zu einem Button hinzugefügt, dessen Click-Function betätigt wird wenn eine Tabellenzeile auf eine Drop-Area gezogen wird. Siehe auch Anmerkungen in JQueryEasyUI-Template.
