### PR TITLE
#FIX Beheben von Problemen mit StateMachines

### DIFF
--- a/Behaviors/StateMachineBehavior.php
+++ b/Behaviors/StateMachineBehavior.php
@@ -297,7 +297,12 @@ class StateMachineBehavior extends AbstractBehavior {
 		if (($widget instanceof iShowSingleAttribute)
 				&& ($disabled_attributes = $this->get_state($current_state)->get_disabled_attributes_aliases())
 				&& in_array($widget->get_attribute_alias(), $disabled_attributes)) {
-			$widget->set_disabled(true);
+			// set_readonly() statt set_disabled(), dadurch werden die deaktivierten
+			// Widgets nicht gespeichert. Behebt einen Fehler, der dadurch ausgeloest
+			// wurde, dass ein deaktiviertes Widget durch einen Link geaendert wurde,
+			// und sich der Wert dadurch vom Wert in der DB unterschied ->
+			// StateMachineUpdateException
+			$widget->set_readonly(true);
 		}
 	}
 	

--- a/Widgets/StateMenuButton.php
+++ b/Widgets/StateMenuButton.php
@@ -40,9 +40,9 @@ class StateMenuButton extends MenuButton {
 					// werden entfernt.
 					/* @var $uxon \exface\Core\CommonLogic\UxonObject */
 					$uxon = $this->get_original_uxon_object()->extend(UxonObject::from_anything($smb_button)->copy());
-					unset($uxon->show_states);
-					unset($uxon->buttons);
-					unset($uxon->menu);
+					$uxon->unset_property('show_states');
+					$uxon->unset_property('buttons');
+					$uxon->unset_property('menu');
 					
 					$button = $this->get_page()->create_widget($button_widget, $this->get_menu(), $uxon);
 					

--- a/Widgets/StateMenuButton.php
+++ b/Widgets/StateMenuButton.php
@@ -35,36 +35,17 @@ class StateMenuButton extends MenuButton {
 				// Ist show_states leer werden alle Buttons hinzugefuegt (default)
 				// sonst wird der Knopf nur hinzugefuegt wenn er in show_states enthalten ist.
 				if (empty($this->get_show_states()) || in_array($target_state, $this->get_show_states())) {
-					// Die Action des StateMenuButtons wird fuer die einzelnen Buttons uebernommen.
-					// Das UxonObject wird weiter im urspruenglichen Zustand benoetigt, daher wird
-					// der Action-Alias nur temporaer gesetzt.
-					// TODO: Das UxonObject sollte besser vor der Aktion kopiert und mit der Kopie
-					// gearbeitet werden. Das Problem ist dass die referenzierten Objekte der
-					// Kopie die selben wie beim Orginal sind, daher das Orginal verändert wird
-					// wenn man mit der Kopie arbeitet.
-					if (!is_null($this->get_action_alias())) {
-						$action_alias_temp = $smb_button->action->alias;
-						$refresh_widget_link_temp = $smb_button->refresh_widget_link;
-						
-						$smb_button->action->alias = $this->get_action_alias();
-						if (!is_null($this->get_refresh_widget_link())) {
-							$smb_button->refresh_widget_link = $this->get_refresh_widget_link()->export_uxon_object();
-						}
-						
-						$button = $this->get_page()->create_widget($button_widget, $this, UxonObject::from_anything($smb_button));
-						
-						$smb_button->action->alias = $action_alias_temp;
-						$smb_button->refresh_widget_link = $refresh_widget_link_temp;
-						
-						// TODO das wäre schöner, muss aber erst ausprobiert werden!
-						/* @var $uxon \exface\Core\CommonLogic\UxonObject */
-						// $uxon = $this->get_original_uxon_object()->extend(UxonObject::from_anything($smb_button)->copy());
-						// $button = $this->get_page()->create_widget($button_widget, $this, $uxon);
-						
-					} else {
-						$button = $this->get_page()->create_widget($button_widget, $this, UxonObject::from_anything($smb_button));
-					}
-
+					// Die Eigenschaften des StateMenuButtons werden fuer die einzelnen Buttons
+					// uebernommen. Alle exklusiven Eigenschaften von MenuButton und StateMenuButton
+					// werden entfernt.
+					/* @var $uxon \exface\Core\CommonLogic\UxonObject */
+					$uxon = $this->get_original_uxon_object()->extend(UxonObject::from_anything($smb_button)->copy());
+					unset($uxon->show_states);
+					unset($uxon->buttons);
+					unset($uxon->menu);
+					
+					$button = $this->get_page()->create_widget($button_widget, $this->get_menu(), $uxon);
+					
                     /** @var StateMachineState $stateObject */
                     $stateObject = $states[$target_state];
 					$name = $stateObject->getStateName($this->get_meta_object()->get_app()->get_translator());


### PR DESCRIPTION
StateMachineBehavior:
- Deaktivierte Widgets werden readonly statt disabled gesetzt. Dadurch werden die deaktivierten Widgets nicht gespeichert. Das behebt einen Fehler, der dadurch ausgeloest wurde, dass ein deaktiviertes Widget durch einen Link geaendert wurde, und sich der Wert dadurch vom Wert in der Datenbank unterschied. Daraus folgte eine StateMachineUpdateException beim Speichern des Objekts.

StateMenuButton:
- Ändern des Status über Buttons bewirkte nichts mehr (Status wurde nicht geändert). Die Ursache dafür war, dass die Buttons als parent den StateMenuButton, und nicht das enthaltene Menü hatten. Dadurch konnten ihre Widgets und das angehängte InputDataSheet nicht mehr gefunden werden. Das wurde repariert.
- Weiterhin wurde die komische Konstruktion, bei der das UxonObjekt erst verändert wurde und am Ende die Änderungen wieder rückgängig gemacht wurden, entfernt. Die Ursache war, dass die copy()-Funktion keine vollkommen unabhängige Kopie des Orginalobjektes erstellt hat. Das wurde behoben, wodurch das UxonObjekt jetzt einfach kopiert werden kann.
