### PR TITLE
prevent possible log recursion

### DIFF
--- a/CommonLogic/Log/Handlers/DebugMessageFileHandler.php
+++ b/CommonLogic/Log/Handlers/DebugMessageFileHandler.php
@@ -37,6 +37,11 @@ class DebugMessageFileHandler implements LogHandlerInterface
 
     public function handle($level, $message, array $context = array(), iCanGenerateDebugWidgets $sender = null)
     {
+        // check log level and return if it is smaller than min log level, otherwise debug widget will be created also
+        // if this is not logged in the underlying log handler
+        if (\Monolog\Logger::toMonologLevel($level) < \Monolog\Logger::toMonologLevel($this->minLogLevel))
+            return true;
+
         if ($sender) {
             $fileName = $context["id"] . $this->staticFilenamePart;
             if (! $fileName) {

--- a/CommonLogic/Log/Handlers/DebugMessageFileHandler.php
+++ b/CommonLogic/Log/Handlers/DebugMessageFileHandler.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace exface\Core\CommonLogic\Log\Handlers;
 
 use exface\Core\CommonLogic\Log\Formatters\MessageOnlyFormatter;
+use exface\Core\CommonLogic\Log\Helpers\LogHelper;
 use exface\Core\Factories\UiPageFactory;
 use exface\Core\Interfaces\iCanGenerateDebugWidgets;
 use exface\Core\Interfaces\Log\LogHandlerInterface;
@@ -30,30 +32,31 @@ class DebugMessageFileHandler implements LogHandlerInterface
      */
     function __construct($dir, $staticFilenamePart, $minLogLevel = Logger::DEBUG)
     {
-        $this->dir = $dir;
+        $this->dir                = $dir;
         $this->staticFilenamePart = $staticFilenamePart;
-        $this->minLogLevel = $minLogLevel;
+        $this->minLogLevel        = $minLogLevel;
     }
 
     public function handle($level, $message, array $context = array(), iCanGenerateDebugWidgets $sender = null)
     {
         // check log level and return if it is smaller than min log level, otherwise debug widget will be created also
         // if this is not logged in the underlying log handler
-        if (\Monolog\Logger::toMonologLevel($level) < \Monolog\Logger::toMonologLevel($this->minLogLevel))
-            return true;
+        if (LogHelper::compareLogLevels($level, $this->minLogLevel) < 0) {
+            return;
+        }
 
         if ($sender) {
             $fileName = $context["id"] . $this->staticFilenamePart;
-            if (! $fileName) {
+            if (!$fileName) {
                 return;
             }
-            
-            $logger = new \Monolog\Logger("Stacktrace");
+
+            $logger  = new \Monolog\Logger("Stacktrace");
             $handler = new StreamHandler($this->dir . "/" . $fileName, $this->minLogLevel);
             $handler->setFormatter(new MessageOnlyFormatter());
             $logger->pushHandler($handler);
-            
-            $debugWidget = $sender->createDebugWidget($this->createDebugMessage());
+
+            $debugWidget     = $sender->createDebugWidget($this->createDebugMessage());
             $debugWidgetData = $debugWidget->exportUxonObject()->toJson(true);
             $logger->log($level, $debugWidgetData);
         }
@@ -65,19 +68,19 @@ class DebugMessageFileHandler implements LogHandlerInterface
         if (isset($context["exception"])) {
             unset($context["exception"]);
         }
-        
+
         return $context;
     }
 
     protected function createDebugMessage()
     {
         global $exface;
-        $ui = $exface->ui();
+        $ui   = $exface->ui();
         $page = UiPageFactory::createEmpty($ui);
-        
+
         $debugMessage = new DebugMessage($page);
         $debugMessage->setMetaObject($page->getWorkbench()->model()->getObject('exface.Core.ERROR'));
-        
+
         return $debugMessage;
     }
 }

--- a/CommonLogic/Log/Helpers/LogHelper.php
+++ b/CommonLogic/Log/Helpers/LogHelper.php
@@ -1,6 +1,8 @@
 <?php
 namespace exface\Core\CommonLogic\Log\Helpers;
 
+use Monolog\Logger;
+
 class LogHelper
 {
 
@@ -62,5 +64,10 @@ class LogHelper
         }
         
         return $glob;
+    }
+
+    public static function compareLogLevels($level1, $level2)
+    {
+        return Logger::toMonologLevel($level1) - Logger::toMonologLevel($level2);
     }
 }


### PR DESCRIPTION
Das Logging wird jetzt auf Grundlage des Levels ggf. früher abgebrochen, so dass der ganze Prozess zum Erstellen des Debug-Widgets nicht angestoßen wird.

Das allein ist aber keine wirkliche Lösung des Problems. Sobald ein Logging an so einer Stelle wie dem SQL-query mit einem Level erfolgt, der tatsächlich zu einem Log-Eintrag führt, hat man das Problem wieder, dass innerhalb des Loggings ein erneuter Log-Vorgang angestoßen wird -> "PHP Fatal error:  Maximum function nesting level of 'xxx' reached, aborting!".

Deshalb habe ich den Mechanismus so erweitert, dass das Logging nur auf der "ersten Ebene" tatsächlich ausgeführt wird. Das Schreiben in  $_REQUEST finde ich zwar nicht so schön, aber so ist sichergestellt, dass sich das Ganze nicht dauerhaft verklemmt.
