### PR TITLE
#FIX Fehler bei setReadOnly() und Text-Widgets

### DIFF
--- a/Behaviors/StateMachineBehavior.php
+++ b/Behaviors/StateMachineBehavior.php
@@ -334,7 +334,11 @@ class StateMachineBehavior extends AbstractBehavior
             // wurde, dass ein deaktiviertes Widget durch einen Link geaendert wurde,
             // und sich der Wert dadurch vom Wert in der DB unterschied ->
             // StateMachineUpdateException
-            $widget->setReadonly(true);
+            if (method_exists($widget, 'setReadonly')) {
+                $widget->setReadonly(true);
+            } else {
+                $widget->setDisabled(true);
+            }
         }
     }
 


### PR DESCRIPTION
Text-Widgets besitzen keine setReadOnly-Methode. Deshalb wird geprueft ob setReadOnly() existiert, sonst wird setDisabled() verwendet.