### PR TITLE
fix for problems in context init

### DIFF
--- a/CommonLogic/Log/Processors/ActionAliasProcessor.php
+++ b/CommonLogic/Log/Processors/ActionAliasProcessor.php
@@ -12,7 +12,7 @@ class ActionAliasProcessor extends AbstractColumnPositionProcessor
 
     protected function getContent()
     {
-        $currentAction = $this->getWorkbench()->context()->getScopeWindow()->getActionContext()->getCurrentAction();
+        $currentAction = $this->getCurrentAction();
         if ($currentAction) {
             return $currentAction->getAliasWithNamespace();
         }
@@ -23,5 +23,26 @@ class ActionAliasProcessor extends AbstractColumnPositionProcessor
     protected function getIndexColumns()
     {
         return array('actionAlias', 'requestId', 'id');
+    }
+
+    protected function getCurrentAction()
+    {
+        $wb = $this->getWorkbench();
+        if (!$wb)
+            return false;
+
+        $ctx = $wb->context();
+        if (!$ctx)
+            return false;
+
+        $sw = $ctx->getScopeWindow();
+        if (!$sw)
+            return false;
+
+        $aCtx = $sw->getActionContext();
+        if (!$aCtx)
+            return false;
+
+        return $aCtx->getCurrentAction();
     }
 }


### PR DESCRIPTION
Zur Behebung von Problemen mit dem Logging während der Initialisierung des Contexts in Workbench->start(), die auf dem AXIDES-INT System auftreten.