### PR TITLE
ids for non exceptions log entries

### DIFF
--- a/CommonLogic/Log/Helpers/LogHelper.php
+++ b/CommonLogic/Log/Helpers/LogHelper.php
@@ -79,4 +79,9 @@ class LogHelper
     {
         return Logger::toMonologLevel($level1) - Logger::toMonologLevel($level2);
     }
+
+    public static function createId()
+    {
+        return strtoupper(substr(md5(uniqid(rand(), true)), 0, 8));
+    }
 }

--- a/CommonLogic/Log/Logger.php
+++ b/CommonLogic/Log/Logger.php
@@ -1,6 +1,7 @@
 <?php
 namespace exface\Core\CommonLogic\Log;
 
+use exface\Core\CommonLogic\Log\Helpers\LogHelper;
 use exface\Core\Exceptions\UnderflowException;
 use exface\Core\Interfaces\iCanGenerateDebugWidgets;
 use exface\Core\Interfaces\Log\LoggerInterface;
@@ -167,6 +168,8 @@ class Logger implements LoggerInterface
                 }
                 $context['exception'] = $sender;
                 $context['id']        = $sender->getId();
+            } else {
+                $context['id']        = LogHelper::createId();
             }
 
             foreach ($this->handlers as $handler) {


### PR DESCRIPTION
Durch diesen PR werden den Notices (und allen anderen Logs, die nicht durch eine Exception getriggert sind) ebenfalls IDs zugeordnet, wodurch man nun z.B. die SQLs der Notices aus dem AbstractDataConnector sehen kann.
