### PR TITLE
fix for FingersCrossedHandler working over multiple files (detail logs)

### DIFF
--- a/CommonLogic/Log/Handlers/DirStreamHandler.php
+++ b/CommonLogic/Log/Handlers/DirStreamHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace exface\Core\CommonLogic\Log\Handlers;
+
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+
+class DirStreamHandler extends StreamHandler
+{
+    private $baseUrl = null;
+
+    public function __construct(
+        $stream,
+        $level = Logger::DEBUG,
+        $bubble = true,
+        $filePermission = null,
+        $useLocking = false
+    ) {
+        $this->baseUrl = $stream;
+        parent::__construct($stream, $level, $bubble, $filePermission, $useLocking);
+    }
+
+
+    protected function write(array $record)
+    {
+        $this->stream = null;
+        $this->url    = $this->baseUrl . $record['context']['filename'];
+
+        parent::write($record);
+    }
+}


### PR DESCRIPTION
Der Fix von gestern bzgl. der Detail-Logs war noch nicht alles. Normalerweise arbeitet der FingersCrossedHandler auf einer Datei. Im Fall der Detail-Logs soll er aber die Steuerung oberhalb mehrerer verschiedener Dateien (der Detail-Logs) übernehmen und bestimmte (z.B. die Notices) Files nur in bestimmten Fällen schreiben.
Das funktioniert in der aktuellen Implementierung (Fix von gestern) noch nicht richtig. Da wird immer in die gleiche (die erste) Detail-Log-Datei geschrieben, wodurch am Ende nur eine Detail-Datei vorhanden ist. Die anderen Log-Einträge, die im gleichen Log-Vorgang geschrieben werden sollten, haben dann keine Detail-Datei.
Dieser PR behebt das. Der FingersCrossedHandler arbeitet wie gewohnt, aber nicht mit einem darunter liegenden StreamHandler, sondern mit einem DirStreamHandler, der eine Basis-Verzeichnis (das Detail-Logs-Verzeichnis hat) und beim rausschreiben immer den richtigen Dateiname setzt. Dadurch werden alle Detail-Logs, die der FingersCrossedHandler "durchlässt" in die richtigen Dateien geschrieben.