### PR TITLE
#FIX Ist kein Alignment angegeben wird es auf default gesetzt

### DIFF
--- a/Widgets/Traits/iCanBeAlignedTrait.php
+++ b/Widgets/Traits/iCanBeAlignedTrait.php
@@ -13,6 +13,9 @@ trait iCanBeAlignedTrait {
      */
     public function getAlign()
     {
+        if ($this->align == null) {
+            $this->setAlign('default'); 
+        }
         return $this->align;
     }
     


### PR DESCRIPTION
Das loest das Problem, bei welchem eine Fehlermeldung flog wenn an einem StateMenuButton kein align gesetzt war. Bei visibility war es bereits ähnlich gelöst.
