### PR TITLE
FIX Sql QueryBuilder vergleicht Strings ohne Anfuehrungszeichen

### DIFF
--- a/QueryBuilders/AbstractSqlBuilder.php
+++ b/QueryBuilders/AbstractSqlBuilder.php
@@ -1290,7 +1290,11 @@ abstract class AbstractSqlBuilder extends AbstractQueryBuilder
                 $output = "(" . $subject . " NOT IN " . $value . ")";
                 break; // The braces are needed if there is a OR IS NULL addition (see above)
             case EXF_COMPARATOR_EQUALS:
-                $output = $subject . " = " . $this->prepareWhereValue($value, $data_type, $sql_data_type);
+                if ($data_type instanceof StringDataType) {
+                    $output = $subject . " = '" . $this->prepareWhereValue($value, $data_type, $sql_data_type) . "'";
+                } else {
+                    $output = $subject . " = " . $this->prepareWhereValue($value, $data_type, $sql_data_type);
+                }
                 break;
             case EXF_COMPARATOR_EQUALS_NOT:
                 $output = $subject . " != " . $this->prepareWhereValue($value, $data_type, $sql_data_type);


### PR DESCRIPTION
Dieser Fehler fiel auf, als ich versuchte einen exface.Core.USER
auszulesen und ein Filter auf den Username gesetzt war. Die
erzeugte Query enthielt "WHERE username = test" statt "WHERE
username = 'test'" und erzeugte dadurch einen Fehler, da test als
Spaltenname interpretiert wurde.