### PR TITLE
Icon Functions

### DIFF
--- a/CommonLogic/Constants/Icons.php
+++ b/CommonLogic/Constants/Icons.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace exface\Core\CommonLogic\Constants;
+use ReflectionClass;
 
 /**
  * Icon names for basic icons supported by all templates.
@@ -657,6 +658,24 @@ abstract class Icons
         
         return false;
     }
+
+    /**
+     * Returns TRUE if the given icon name exists in this class and FALSE otherwise
+     * @param string $icon
+     * @return boolean
+     */
+    public static function isDefinedIcon($icon){
+        $icons = self::getConstants();
+        if (array_key_exists($icon, $icons)){
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Returns the associated icon string to the constant name given in $icon
+     * @param string $icon
+     * @return string
+     */
     public static function getIcon($icon){
         $icons = self::getConstants();
         if (array_key_exists($icon, $icons)){
@@ -664,7 +683,10 @@ abstract class Icons
         }
         return self::WRENCH;
     }
-
+    /**
+     * Grabs all icon constants with the help of the ReflectionClass
+     * @return array
+     */
     private static function getConstants() {
         $oClass = new ReflectionClass(__CLASS__);
         return $oClass->getConstants();

--- a/CommonLogic/Constants/Icons.php
+++ b/CommonLogic/Constants/Icons.php
@@ -657,4 +657,16 @@ abstract class Icons
         
         return false;
     }
+    public static function getIcon($icon){
+        $icons = self::getConstants();
+        if (array_key_exists($icon, $icons)){
+            return $icons[$icon];
+        }
+        return self::WRENCH;
+    }
+
+    private static function getConstants() {
+        $oClass = new ReflectionClass(__CLASS__);
+        return $oClass->getConstants();
+    }
 }


### PR DESCRIPTION
Wrapper functions to get class constants not by name association but key - value association. Gives a fail safe for the possibility of icons that are not defined by name.