### PR TITLE
FIX Fehler beim Instanziieren der Workbench beim Deployment

### DIFF
--- a/CommonLogic/Workbench.php
+++ b/CommonLogic/Workbench.php
@@ -231,13 +231,29 @@ class Workbench
         }
     }
 
+    /**
+     * Returns an app, defined by its UID or alias, from the running_apps.
+     * 
+     * @param string $appUidOrAlias
+     * @return AppInterface|null
+     */
     protected function findAppByUidOrAlias($appUidOrAlias)
     {
-        foreach ($this->running_apps as $app) {
-            // Um die Uid der App zu erhalten muss das Model bereits existieren, sonst
-            // kommt es zu einem Fehler in app->getUid()
-            if (strcasecmp($app->getAliasWithNamespace(), $appUidOrAlias) === 0 || ($this->model() && strcasecmp($app->getUid(), $appUidOrAlias) === 0)) {
-                return $app;
+        if (AppFactory::isUid($appUidOrAlias) && $this->model()) {
+            // Die App-UID darf nur abgefragt werden, wenn tatsaechlich eine UID ueber-
+            // geben wird, sonst kommt es zu Problemen beim Update. Um die UID der App zu
+            // erhalten muss ausserdem das Model bereits existieren, sonst kommt es zu
+            // einem Fehler in app->getUid().
+            foreach ($this->running_apps as $app) {
+                if (strcasecmp($app->getUid(), $appUidOrAlias) === 0) {
+                    return $app;
+                }
+            }
+        } else {
+            foreach ($this->running_apps as $app) {
+                if (strcasecmp($app->getAliasWithNamespace(), $appUidOrAlias) === 0) {
+                    return $app;
+                }
             }
         }
         return null;


### PR DESCRIPTION
Dieser Fix behebt das Problem, dass die Workbench beim Update von einem alten Stand nicht instanziiert werden kann. Vorher wurde immer die App UID abgefragt, jetzt nur noch wenn tatsächlich eine UID und kein Alias übergeben wurde.
