### PR TITLE
FIX OutOfMemory Error bei Wiederherstellung aus Logs

### DIFF
--- a/Templates/AbstractAjaxTemplate/Elements/JqueryDataTablesTrait.php
+++ b/Templates/AbstractAjaxTemplate/Elements/JqueryDataTablesTrait.php
@@ -287,7 +287,9 @@ JS;
 				    }
 				    
 				    $data = $widget->prepareDataSheetToRead($data ? $data : null);
-				    
+				    if (is_null($data->getRowsOnPage())) {
+				        $data->setRowsOnPage($this->getTemplate()->getConfig()->getOption('WIDGET.DATATABLE.PAGE_SIZE'));
+				    }
 				    if (! $data->isFresh()) {
 				        $data->dataRead();
 				    }


### PR DESCRIPTION
Wird versucht eine Fehlermeldung mit einer DataTable mit fehlerhaften Datensaetzen (aus Rueckstandsliste) aus den Logs wiederherzustellen, wird versucht 23000 Datensaetze zu Laden was zu einem OutOfMemoryError fuehrt. Deshalb wird hier die Zahl der zu ladenden Datensaetze eingeschraenkt.
