### PR TITLE
FIX leftover usage of removed constants fixed in DataConnectionFactory

### DIFF
--- a/Factories/DataConnectionFactory.php
+++ b/Factories/DataConnectionFactory.php
@@ -122,8 +122,8 @@ abstract class DataConnectionFactory extends AbstractSelectableComponentFactory
             $selector = new DataConnectionSelector($workbench, $uidOrAliasOrSelector);
         }
         switch (true) {
-            case $selector->isAlias() && strcasecmp($uidOrAliasOrSelector, self::METAMODEL_CONNECTION_ALIAS_NAMESPACE . AliasSelectorInterface::ALIAS_NAMESPACE_DELIMITER . self::METAMODEL_CONNECTION_ALIAS) === 0:
-            case $selector->isUid() && strcasecmp($uidOrAliasOrSelector, self::METAMODEL_CONNECTION_UID) === 0:
+            case $selector->isAlias() && strcasecmp($uidOrAliasOrSelector, DataConnectionSelector::findNamespace(DataConnectionSelector::METAMODEL_CONNECTION_ALIAS) . AliasSelectorInterface::ALIAS_NAMESPACE_DELIMITER . DataConnectionSelector::stripNamespace(DataConnectionSelector::METAMODEL_CONNECTION_ALIAS)) === 0:
+            case $selector->isUid() && strcasecmp($uidOrAliasOrSelector, DataConnectionSelector::METAMODEL_CONNECTION_UID) === 0:
                 return $workbench->model()->getModelLoader()->getDataConnection();
             default:
                 return $workbench->model()->getModelLoader()->loadDataConnection($selector);


### PR DESCRIPTION
- FIX in the commit to add namespaces to data sources there were leftovers of using removed constants in the DataConnectionFactory, this got fixed now