### PR TITLE
FIX data row placeholders were empty after first row

### DIFF
--- a/Templates/Placeholders/DataRowPlaceholders.php
+++ b/Templates/Placeholders/DataRowPlaceholders.php
@@ -74,7 +74,7 @@ class DataRowPlaceholders implements PlaceholderResolverInterface
         
         foreach ($phs as $ph) {
             $col = $phSheet->getColumns()->getByExpression($this->stripPrefix($ph, $this->prefix));
-            $val = $col->getValue($this->rowNumber);
+            $val = $col->getValue(0);
             $phVals[$ph] = $this->isFormattingValues() ? $col->getDataType()->format($val) : $val;
         }
         


### PR DESCRIPTION
The data row placeholder did return only empty placeholder values for rows after the first row