### PR TITLE
FIX compare values not type sensitive in condition evaluation, throw error if column for placeholder does not exist in data sheet

### DIFF
--- a/CommonLogic/Model/Condition.php
+++ b/CommonLogic/Model/Condition.php
@@ -532,9 +532,9 @@ class Condition implements ConditionInterface
             case ComparatorDataType::IS_NOT:
                 return mb_stripos(($leftVal ?? ''), ($rightVal ?? '')) === false;
             case ComparatorDataType::EQUALS:
-                return $leftVal === $rightVal;
+                return $leftVal == $rightVal;
             case ComparatorDataType::EQUALS_NOT:
-                return $leftVal !== $rightVal;
+                return $leftVal != $rightVal;
             case ComparatorDataType::GREATER_THAN:
                 return $leftVal > $rightVal;
             case ComparatorDataType::LESS_THAN:

--- a/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
@@ -1002,7 +1002,7 @@ JS;
                         $conditionJs = <<<JS
 
             var aSourcenew = [];
-            var oConditionGroup = {'operator': "{$filters->getOperator()}"};
+            var oConditionGroup = {'operator': "{$filters->getConditionGroup()->getOperator()}"};
             var aConditions = [];
 JS;
                         foreach ($filters->getConditions() as $key => $cond) {

--- a/Templates/Placeholders/DataRowPlaceholders.php
+++ b/Templates/Placeholders/DataRowPlaceholders.php
@@ -7,6 +7,7 @@ use exface\Core\CommonLogic\TemplateRenderer\Traits\PrefixedPlaceholderTrait;
 use exface\Core\Interfaces\DataSheets\DataSheetInterface;
 use exface\Core\Factories\DataSheetFactory;
 use exface\Core\CommonLogic\TemplateRenderer\Traits\SanitizedPlaceholderTrait;
+use exface\Core\Exceptions\DataSheets\DataSheetColumnNotFoundError;
 
 /**
  * Resolves placeholders to facade propertis: `~facade:property`.
@@ -79,6 +80,9 @@ class DataRowPlaceholders implements PlaceholderResolverInterface
         
         foreach ($phs as $ph) {
             $col = $phSheet->getColumns()->getByExpression($this->stripPrefix($ph, $this->prefix));
+            if ($col == false) {
+                throw new DataSheetColumnNotFoundError($phSheet, "Column to replace placeholder '{$ph}' not found in data sheet and it could not be loaded automatically.");
+            }
             $val = $col->getValue($phRowNo);
             $formatted = $this->isFormattingValues() ? $col->getDataType()->format($val) : $val;
             $phVals[$ph] = $this->sanitizeValue($formatted);

--- a/Widgets/InputComboTable.php
+++ b/Widgets/InputComboTable.php
@@ -891,7 +891,7 @@ class InputComboTable extends InputCombo implements iCanPreloadData
                 $rel = $this->getAttribute()->getRelation();
                 $sheet = $this->getTable()->prepareDataSheetToRead(DataSheetFactory::createFromObject($rel->getRightObject()));
                 if (null !== ($filters = $this->getFilters())) {
-                    $condGroup = ConditionGroupFactory::createForDataSheet($sheet, $filters->getOperator());
+                    $condGroup = ConditionGroupFactory::createForDataSheet($sheet, $filters->getConditionGroup()->getOperator());
                     foreach ($filters->getConditions() as $cond) {
                         /* @var $cond \exface\Core\Widgets\Parts\ConditionalPropertyCondition */
                         if ($cond->hasLiveReference()) {


### PR DESCRIPTION
- FIX compare values not type sensitive in condition evaluation
- FIX throw error if column for placeholder does not exist in data sheet
- FIX programmatical error fixed in InputComboTable and JExcelTrait