### PR TITLE
DEV AD-synchronisation change user pages to add keeping of manual roles

### DIFF
--- a/Model/99_PAGE/exface.core.authenticators.json
+++ b/Model/99_PAGE/exface.core.authenticators.json
@@ -2,7 +2,7 @@
     "uid": "0x11ea860ba247621397940205857feb80",
     "alias_with_namespace": "exface.core.authenticators",
     "menu_parent_page_selector": "0x11ea5edc2f798596b9920205857feb80",
-    "menu_index": 6,
+    "menu_index": 5,
     "menu_visible": true,
     "name": "Login Types",
     "description": "View active authenticators",
@@ -10,8 +10,8 @@
     "replaces_page_selector": null,
     "created_by_user_selector": "0x31000000000000000000000000000000",
     "created_on": "2020-04-24 09:12:01",
-    "modified_by_user_selector": "0x11e8fe1c902c8ebea23ee4b318306b9a",
-    "modified_on": "2023-09-08 12:38:01",
+    "modified_by_user_selector": "0x11ed9f5019075a8a9f50025041000001",
+    "modified_on": "2024-05-23 09:07:36",
     "contents": {
         "widget_type": "SplitHorizontal",
         "object_alias": "exface.Core.AUTHENTICATOR",
@@ -98,11 +98,20 @@
                             },
                             {
                                 "attribute_alias": "ALIAS"
+                            },
+                            {
+                                "attribute_alias": "AUTHENTICATOR"
+                            },
+                            {
+                                "attribute_alias": "USER_ROLE"
                             }
                         ],
                         "columns": [
                             {
                                 "attribute_alias": "ACTIVE_FLAG"
+                            },
+                            {
+                                "attribute_alias": "KEEP_MANUAL_ASSIGNMENTS_FLAG"
                             },
                             {
                                 "attribute_alias": "NAME"
@@ -144,6 +153,12 @@
                             },
                             {
                                 "action_alias": "exface.Core.UserRoleExternalDisable"
+                            },
+                            {
+                                "action_alias": "exface.Core.KeepManualAssingments"
+                            },
+                            {
+                                "action_alias": "exface.Core.SyncManualAssignments"
                             }
                         ]
                     }

--- a/Model/99_PAGE/exface.core.local-external-monitoring.json
+++ b/Model/99_PAGE/exface.core.local-external-monitoring.json
@@ -1,0 +1,130 @@
+{
+    "uid": "0x11ef80f2857c613280f2025041000001",
+    "alias_with_namespace": "exface.core.local-external-monitoring",
+    "menu_parent_page_selector": "0x11ea5edc2f798596b9920205857feb80",
+    "menu_index": 3,
+    "menu_visible": true,
+    "name": "Local\/External Monitoring",
+    "description": "Compare local and external roles",
+    "intro": "",
+    "replaces_page_selector": null,
+    "created_by_user_selector": "0x11ed9f5019075a8a9f50025041000001",
+    "created_on": "2024-05-15 09:12:42",
+    "modified_by_user_selector": "0x11ed9f5019075a8a9f50025041000001",
+    "modified_on": "2024-05-15 09:34:08",
+    "contents": {
+        "widget_type": "SplitHorizontal",
+        "object_alias": "exface.Core.USER_ROLE",
+        "panels": [
+            {
+                "caption": "Local roles",
+                "width": "33%",
+                "widgets": [
+                    {
+                        "widget_type": "DataTable",
+                        "object_alias": "exface.Core.USER_ROLE_USERS",
+                        "nowrap": false,
+                        "id": "local_table",
+                        "filters": [
+                            {
+                                "attribute_alias": "USER__LABEL",
+                                "widget_type": "InputComboTable",
+                                "apply_on_change": true,
+                                "multi_select": true,
+                                "id": "user_filter"
+                            },
+                            {
+                                "attribute_alias": "USER_ROLE__LABEL",
+                                "widget_type": "InputComboTable",
+                                "apply_on_change": true,
+                                "multi_select": true,
+                                "id": "role_filter"
+                            },
+                            {
+                                "attribute_alias": "AUTHENTICATOR_ID",
+                                "comparator": "<",
+                                "value": 1,
+                                "hidden": true
+                            }
+                        ],
+                        "columns": [
+                            {
+                                "attribute_alias": "USER__LABEL"
+                            },
+                            {
+                                "attribute_alias": "USER_ROLE__LABEL"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "caption": "External roles",
+                "width": "33%",
+                "widgets": [
+                    {
+                        "widget_type": "DataTable",
+                        "object_alias": "exface.Core.USER_ROLE_USERS",
+                        "multi_select": true,
+                        "id": "external_table",
+                        "filters": [
+                            {
+                                "attribute_alias": "USER__LABEL",
+                                "value": "=user_filter",
+                                "hidden": true,
+                                "apply_on_change": true
+                            },
+                            {
+                                "attribute_alias": "USER_ROLE__LABEL",
+                                "value": "=role_filter",
+                                "hidden": true,
+                                "apply_on_change": true
+                            },
+                            {
+                                "attribute_alias": "AUTHENTICATOR_ID",
+                                "comparator": ">",
+                                "value": 0,
+                                "hidden": true
+                            }
+                        ],
+                        "columns": [
+                            {
+                                "attribute_alias": "USER__LABEL"
+                            },
+                            {
+                                "attribute_alias": "USER_ROLE__LABEL"
+                            },
+                            {
+                                "attribute_alias": "AUTHENTICATOR_ID"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "caption": "AD groups of logged in user",
+                "width": "33%",
+                "widgets": [
+                    {
+                        "widget_type": "DataTable",
+                        "object_alias": "axenox.Microsoft365Connector.meGroups",
+                        "filters": [
+                            {
+                                "attribute_alias": "displayName",
+                                "widget_type": "InputComboTable",
+                                "multi_select": true,
+                                "apply_on_change": true
+                            }
+                        ],
+                        "columns": [
+                            {
+                                "attribute_alias": "displayName"
+                            }
+                        ],
+                        "paginate": false
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/Model/99_PAGE/exface.core.user-roles.json
+++ b/Model/99_PAGE/exface.core.user-roles.json
@@ -2,7 +2,7 @@
     "uid": "0x11ea648437c38ffea2e30205857feb80",
     "alias_with_namespace": "exface.core.user-roles",
     "menu_parent_page_selector": "0x11ea5edc2f798596b9920205857feb80",
-    "menu_index": 4,
+    "menu_index": 3,
     "menu_visible": true,
     "name": "User Roles",
     "description": "Group users to assign permissions",
@@ -10,8 +10,8 @@
     "replaces_page_selector": null,
     "created_by_user_selector": "0x31000000000000000000000000000000",
     "created_on": "2020-03-12 17:09:23",
-    "modified_by_user_selector": "0x11e8fe1c902c8ebea23ee4b318306b9a",
-    "modified_on": "2023-09-08 12:38:01",
+    "modified_by_user_selector": "0x11ed9f5019075a8a9f50025041000001",
+    "modified_on": "2024-05-23 09:06:02",
     "contents": {
         "widget_type": "SplitHorizontal",
         "object_alias": "exface.Core.USER_ROLE",
@@ -96,6 +96,29 @@
                         "widget_type": "DataTable",
                         "object_alias": "exface.Core.USER_ROLE_EXTERNAL",
                         "multi_select": true,
+                        "columns": [
+                            {
+                                "attribute_alias": "ACTIVE_FLAG"
+                            },
+                            {
+                                "attribute_alias": "KEEP_MANUAL_ASSIGNMENTS_FLAG"
+                            },
+                            {
+                                "attribute_alias": "NAME"
+                            },
+                            {
+                                "attribute_alias": "ALIAS"
+                            },
+                            {
+                                "attribute_alias": "AUTHENTICATOR__LABEL"
+                            },
+                            {
+                                "attribute_alias": "USER_ROLE__LABEL"
+                            },
+                            {
+                                "attribute_alias": "CREATED_ON"
+                            }
+                        ],
                         "filters": [
                             {
                                 "attribute_alias": "USER_ROLE",
@@ -112,26 +135,9 @@
                             },
                             {
                                 "attribute_alias": "AUTHENTICATOR"
-                            }
-                        ],
-                        "columns": [
-                            {
-                                "attribute_alias": "ACTIVE_FLAG"
                             },
                             {
-                                "attribute_alias": "NAME"
-                            },
-                            {
-                                "attribute_alias": "ALIAS"
-                            },
-                            {
-                                "attribute_alias": "AUTHENTICATOR__LABEL"
-                            },
-                            {
-                                "attribute_alias": "USER_ROLE__LABEL"
-                            },
-                            {
-                                "attribute_alias": "CREATED_ON"
+                                "attribute_alias": "USER_ROLE"
                             }
                         ],
                         "buttons": [
@@ -150,6 +156,12 @@
                             },
                             {
                                 "action_alias": "exface.Core.UserRoleExternalDisable"
+                            },
+                            {
+                                "action_alias": "exface.Core.KeepManualAssingments"
+                            },
+                            {
+                                "action_alias": "exface.Core.SyncManualAssignments"
                             }
                         ]
                     }

--- a/Model/exface.Core.USER_ROLE_EXTERNAL/02_OBJECT.json
+++ b/Model/exface.Core.USER_ROLE_EXTERNAL/02_OBJECT.json
@@ -81,9 +81,9 @@
     "rows": [
         {
             "CREATED_ON": "2020-04-07 09:01:49",
-            "MODIFIED_ON": "2023-08-29 12:46:58",
+            "MODIFIED_ON": "2024-05-16 09:27:02",
             "CREATED_BY_USER": "0x31000000000000000000000000000000",
-            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
+            "MODIFIED_BY_USER": "0x11ed9f5019075a8a9f50025041000001",
             "UID": "0x11ea78ae6a2c1977ac460205857feb80",
             "READABLE_FLAG": 1,
             "WRITABLE_FLAG": 1,
@@ -122,6 +122,9 @@
                     },
                     {
                         "attribute_alias": "ACTIVE_FLAG"
+                    },
+                    {
+                        "attribute_alias": "KEEP_MANUAL_ASSIGNMENTS_FLAG"
                     }
                 ]
             },


### PR DESCRIPTION
changes to pages "User roles" and "Login types" to add columns and buttons for "keep manual roles".