### PR TITLE
DEV Filter applyToAggregates setting added

### DIFF
--- a/CommonLogic/Model/Condition.php
+++ b/CommonLogic/Model/Condition.php
@@ -72,6 +72,8 @@ class Condition implements ConditionInterface
     
     private $ignoreEmptyValues = null;
 
+    private bool $applyToAggregates = true;
+
     /**
      * @deprecated use ConditionFactory instead!
      * 
@@ -473,6 +475,8 @@ class Condition implements ConditionInterface
         if ($this->ignoreEmptyValues === true) {
             $uxon->setProperty('ignore_empty_values', $this->ignoreEmptyValues);
         }
+        $uxon->setProperty('apply_to_aggregates', $this->applyToAggregates);
+
         return $uxon;
     }
 
@@ -567,9 +571,15 @@ class Condition implements ConditionInterface
             if ($uxon->hasProperty('comparator') && ($comp = $uxon->getProperty('comparator'))) {
                 $this->setComparator($comp);
             }
+
             if (null !== $ignoreEmpty = $uxon->getProperty('ignore_empty_values')) {
-                $this->setIgnoreEmptyValues($ignoreEmpty);
+                $this->setIgnoreEmptyValues(filter_var($ignoreEmpty, FILTER_VALIDATE_BOOLEAN));
             }
+
+            if(null !== $applyToAggregates = $uxon->getProperty('apply_to_aggregates')) {
+                $this->setApplyToAggregates(filter_var($applyToAggregates, FILTER_VALIDATE_BOOLEAN));
+            }
+
             if ($uxon->hasProperty('value') || $value !== null){
                 $value = $value ?? $uxon->getProperty('value');
                 // Apply th evalue only if it is not empty or ignore_empty_values is off
@@ -794,5 +804,34 @@ class Condition implements ConditionInterface
     public function willIgnoreEmptyValues() : bool
     {
         return $this->ignoreEmptyValues;
+    }
+
+    /**
+     * If set to FALSE this condition will not be applied to aggregated values.
+     *
+     * This can be used to fine-tune filters for instance.
+     * The default value is TRUE.
+     *
+     * @uxon-property apply_to_aggregates
+     * @uxon-type boolean
+     * @uxon-default true
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setApplyToAggregates(bool $value) : static
+    {
+        $this->applyToAggregates = $value;
+        return $this;
+    }
+
+    /**
+     * Returns TRUE if this condition applies to aggregated values.
+     *
+     * @return bool
+     */
+    public function appliesToAggregatedValues() : bool
+    {
+        return $this->applyToAggregates;
     }
 }

--- a/CommonLogic/Model/Condition.php
+++ b/CommonLogic/Model/Condition.php
@@ -2,6 +2,7 @@
 namespace exface\Core\CommonLogic\Model;
 
 use exface\Core\CommonLogic\UxonObject;
+use exface\Core\DataTypes\BooleanDataType;
 use exface\Core\Factories\DataTypeFactory;
 use exface\Core\Exceptions\RangeException;
 use exface\Core\Exceptions\UnexpectedValueException;
@@ -572,12 +573,12 @@ class Condition implements ConditionInterface
                 $this->setComparator($comp);
             }
 
-            if (null !== $ignoreEmpty = $uxon->getProperty('ignore_empty_values')) {
-                $this->setIgnoreEmptyValues(filter_var($ignoreEmpty, FILTER_VALIDATE_BOOLEAN));
+            if (null !== $ignoreEmpty = BooleanDataType::cast($uxon->getProperty('ignore_empty_values'))) {
+                $this->setIgnoreEmptyValues($ignoreEmpty);
             }
 
-            if(null !== $applyToAggregates = $uxon->getProperty('apply_to_aggregates')) {
-                $this->setApplyToAggregates(filter_var($applyToAggregates, FILTER_VALIDATE_BOOLEAN));
+            if(null !== $applyToAggregates = BooleanDataType::cast($uxon->getProperty('apply_to_aggregates'))) {
+                $this->setApplyToAggregates($applyToAggregates);
             }
 
             if ($uxon->hasProperty('value') || $value !== null){

--- a/CommonLogic/Model/ConditionGroup.php
+++ b/CommonLogic/Model/ConditionGroup.php
@@ -2,6 +2,7 @@
 namespace exface\Core\CommonLogic\Model;
 
 use exface\Core\CommonLogic\UxonObject;
+use exface\Core\DataTypes\BooleanDataType;
 use exface\Core\Factories\ConditionFactory;
 use exface\Core\Factories\ConditionGroupFactory;
 use exface\Core\Exceptions\Model\ExpressionRebaseImpossibleError;
@@ -435,8 +436,8 @@ class ConditionGroup implements ConditionGroupInterface
     {
         try {
             $this->setOperator($uxon->getProperty('operator') ?? EXF_LOGICAL_AND);
-            if (null !== $ignoreEmpty = $uxon->getProperty('ignore_empty_values')) {
-                $this->setIgnoreEmptyValues(filter_var($ignoreEmpty, FILTER_VALIDATE_BOOLEAN));
+            if (null !== $ignoreEmpty = BooleanDataType::cast($uxon->getProperty('ignore_empty_values'))) {
+                $this->setIgnoreEmptyValues($ignoreEmpty);
             }
             if ($uxon->hasProperty('base_object_alias')) {
                 $this->setBaseObjectAlias($uxon->getProperty('base_object_alias'));

--- a/CommonLogic/Model/ConditionGroup.php
+++ b/CommonLogic/Model/ConditionGroup.php
@@ -436,7 +436,7 @@ class ConditionGroup implements ConditionGroupInterface
         try {
             $this->setOperator($uxon->getProperty('operator') ?? EXF_LOGICAL_AND);
             if (null !== $ignoreEmpty = $uxon->getProperty('ignore_empty_values')) {
-                $this->setIgnoreEmptyValues($ignoreEmpty);
+                $this->setIgnoreEmptyValues(filter_var($ignoreEmpty, FILTER_VALIDATE_BOOLEAN));
             }
             if ($uxon->hasProperty('base_object_alias')) {
                 $this->setBaseObjectAlias($uxon->getProperty('base_object_alias'));

--- a/Facades/AbstractAjaxFacade/Elements/JqueryFilterTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JqueryFilterTrait.php
@@ -25,7 +25,13 @@ trait JqueryFilterTrait {
         if ($widget->getAttributeAlias() === '' || $widget->getAttributeAlias() === null) {
             throw new WidgetConfigurationError($widget, 'Invalid filter configuration for filter "' . $widget->getCaption() . '": missing expression (e.g. attribute_alias)!');
         }
-        return '{expression: "' . $widget->getAttributeAlias() . '", comparator: ' . $this->buildJsComparatorGetter() . ', value: ' . $value . ', object_alias: "' . $widget->getMetaObject()->getAliasWithNamespace() . '"}';
+        return '{'.
+            'expression: "' . $widget->getAttributeAlias() . '", '.
+            'comparator: ' . $this->buildJsComparatorGetter() . ', '.
+            'value: ' . $value . ', '.
+            'object_alias: "' . $widget->getMetaObject()->getAliasWithNamespace() . '", '.
+            'apply_to_aggregates: "' . $widget->appliesToAggregatedValues() . '"'.
+        '}';
     }
     
     public function buildJsCustomConditionGroup($valueJs = null) : string
@@ -34,7 +40,7 @@ trait JqueryFilterTrait {
         if ($widget->hasCustomConditionGroup() === false) {
             return '';
         }
-        
+
         $jsonWithValuePlaceholder = $widget->getCustomConditionGroup()->exportUxonObject()->toJson(false);
         return str_replace('"[#value#]"', $valueJs ?? $this->buildJsValueGetter(), $jsonWithValuePlaceholder);
     }

--- a/Facades/AbstractAjaxFacade/Elements/JqueryFilterTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JqueryFilterTrait.php
@@ -27,13 +27,15 @@ trait JqueryFilterTrait {
         }
 
         $appliesToAggregates = $widget->appliesToAggregatedValues() ? 'true' : 'false';
-        return '{'.
-            'expression: "' . $widget->getAttributeAlias() . '", '.
-            'comparator: ' . $this->buildJsComparatorGetter() . ', '.
-            'value: ' . $value . ', '.
-            'object_alias: "' . $widget->getMetaObject()->getAliasWithNamespace() . '", '.
-            'apply_to_aggregates: "' . $appliesToAggregates . '"'.
-        '}';
+        return <<<JSON
+{
+  "expression" : "{$widget->getAttributeAlias()}",
+  "comparator" : {$this->buildJsComparatorGetter()},
+  "value" : $value,
+  "object_alias" : "{$widget->getMetaObject()->getAliasWithNamespace()}",
+  "apply_to_aggregates" : "{$appliesToAggregates}"
+}
+JSON;
     }
     
     public function buildJsCustomConditionGroup($valueJs = null) : string

--- a/Facades/AbstractAjaxFacade/Elements/JqueryFilterTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JqueryFilterTrait.php
@@ -25,12 +25,14 @@ trait JqueryFilterTrait {
         if ($widget->getAttributeAlias() === '' || $widget->getAttributeAlias() === null) {
             throw new WidgetConfigurationError($widget, 'Invalid filter configuration for filter "' . $widget->getCaption() . '": missing expression (e.g. attribute_alias)!');
         }
+
+        $appliesToAggregates = $widget->appliesToAggregatedValues() ? 'true' : 'false';
         return '{'.
             'expression: "' . $widget->getAttributeAlias() . '", '.
             'comparator: ' . $this->buildJsComparatorGetter() . ', '.
             'value: ' . $value . ', '.
             'object_alias: "' . $widget->getMetaObject()->getAliasWithNamespace() . '", '.
-            'apply_to_aggregates: "' . $widget->appliesToAggregatedValues() . '"'.
+            'apply_to_aggregates: "' . $appliesToAggregates . '"'.
         '}';
     }
     

--- a/QueryBuilders/AbstractSqlBuilder.php
+++ b/QueryBuilders/AbstractSqlBuilder.php
@@ -2227,7 +2227,7 @@ abstract class AbstractSqlBuilder extends AbstractQueryBuilder
      * This is mainly used to handle filters over reversed relations, but also
      * for filters on joined columns in UPDATE queries, where the main query
      * does not support joining. The optional parameter $rely_on_joins controls
-     * whether the method can rely on the main query have all neccessary joins.
+     * whether the method can rely on the main query to have all necessary joins.
      *
      * @param QueryPartFilter $qpart
      * @param boolean $rely_on_joins
@@ -2277,20 +2277,20 @@ abstract class AbstractSqlBuilder extends AbstractQueryBuilder
                 // Remember to keep the aggregator of the attribute filtered over. Since we are interested in a list of keys, the
                 // subquery should GROUP BY these kees.
                 if ($qpart->getAggregator()) {
-                    // IDEA HAVING-subqueries can be very slow. Perhaps we can optimize the subquery a litte in certain cases:
+                    // IDEA HAVING-subqueries can be very slow. Perhaps we can optimize the subquery a little in certain cases:
                     // e.g. if we are filtering over a SUM of natural numbers with "> 0", we could simply add a "> 0" filter
-                    // without any aggregation and it should yield the same results
+                    // without any aggregation, and it should yield the same results
                     $rel_filter_alias .= DataAggregation::AGGREGATION_SEPARATOR . $qpart->getAggregator()->exportString();
                     $relq->addAggregation($start_rel->getRightKeyAttribute()->getAlias());
                     
                     // If we are in a WHERE subquery of a filter with an aggregator, this means, we want to filter
                     // over the aggregated value. However, there might be other filters, that affect this aggregated
                     // value: e.g. as SUM over transactions for a product will be different depending on the store
-                    // filter set for the query. So we need all applicale non-aggregating filters in our subquery.
+                    // filter set for the query. So we need all applicable non-aggregating filters in our subquery.
                     // This is achieved by rebasing all filters with the following filter callback, that excludes
                     // certain conditions.
                     $relq_condition_filter = function($condition, $relation_path_to_new_base_object) use ($qpart) {
-                        // If the condition is not an attribute, keep it - other partsof the code will deal with it
+                        // If the condition is not an attribute, keep it - other parts of the code will deal with it
                         if (! $condition->getExpression()->isMetaAttribute()) {
                             return true;
                         }
@@ -2299,7 +2299,7 @@ abstract class AbstractSqlBuilder extends AbstractQueryBuilder
                         if ($condition->getExpression()->toString() === $qpart->getExpression()->toString()){
                             return false;
                         }
-                        // If a conditon  has an aggregator itself - skip it as it will get it's own subquery.
+                        // If a condition  has an aggregator itself - skip it as it will get its own subquery.
                         if (DataAggregation::getAggregatorFromAlias($this->getWorkbench(), $condition->getExpression()->toString())) {
                             return false;
                         }

--- a/Widgets/Filter.php
+++ b/Widgets/Filter.php
@@ -194,6 +194,8 @@ class Filter extends AbstractWidget implements iFilterData, iTakeInput, iShowSin
     private $preloader = null;
     
     private $useHiddenInput = false;
+
+    private bool $appliesToAggregatedValues = true;
     
     /**
      * Returns TRUE if the input widget was already instantiated.
@@ -1005,6 +1007,34 @@ class Filter extends AbstractWidget implements iFilterData, iTakeInput, iShowSin
     {
         $this->apply_on_change = BooleanDataType::cast($true_or_false);
         return $this;
+    }
+
+    /**
+     * If set to FALSE this filter will not be applied to aggregated values.
+     *
+     * The default value is TRUE.
+     *
+     * @uxon-property apply_to_aggregates
+     * @uxon-type boolean
+     * @uxon-default true
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setApplyToAggregates(bool $value) : static
+    {
+        $this->appliesToAggregatedValues = $value;
+        return $this;
+    }
+
+    /**
+     * Returns TRUE if this filter applies to aggregated values.
+     *
+     * @return bool
+     */
+    public function appliesToAggregatedValues() : bool
+    {
+        return $this->appliesToAggregatedValues;
     }
 
     /**


### PR DESCRIPTION
NOTE 
I discovered a few instances of `$uxon->getProperty('prop')` where the retrieved value was than stuffed into a function like `$this->setProperty(bool $value)`. This is bad, because, unless the uxon property is null or empty, the setter will always evaluate to `true`, even if the property was something along the lines of "false" or "no".

I (hopefully) fixed this issue for the instances I came across, but there might be more.