### PR TITLE
EventCascade

### DIFF
--- a/Behaviors/SynchronizingBehavior.php
+++ b/Behaviors/SynchronizingBehavior.php
@@ -14,17 +14,13 @@ use exface\Core\Events\DataSheet\OnUpdateDataEvent;
 use exface\Core\Exceptions\Behaviors\BehaviorConfigurationError;
 use exface\Core\Factories\DataSheetFactory;
 use exface\Core\Factories\RelationPathFactory;
-use exface\Core\Interfaces\Events\DataSheetEventInterface;
 use exface\Core\Interfaces\Model\BehaviorInterface;
 use exface\Core\CommonLogic\UxonObject;
-use exface\Core\Interfaces\Events\EventInterface;
 use exface\Core\Events\Behavior\OnBeforeBehaviorAppliedEvent;
 use exface\Core\Events\Behavior\OnBehaviorAppliedEvent;
 use exface\Core\CommonLogic\Debugger\LogBooks\BehaviorLogBook;
 
 /**
- * ALPHA! Do not use yet!
- * 
  * Makes a child-object affect its parent whenever it is changed
  * 
  * For example, if we have an `ORDER` object and multiple `ORDER_POS` for that order. Changing the `QTY`
@@ -32,8 +28,10 @@ use exface\Core\CommonLogic\Debugger\LogBooks\BehaviorLogBook;
  * expect the last-change time to update when the quantity of a position is changed.
  * 
  * Technically this means an `OnUpdateData` event of order position is also an `OnUpdateData` for the
- * order. That easy for updates, but less straight-forward for creates or deletes: when a position is created,
- * the order is updated.
+ * order. Other events may be mapped differently, depending on your configuration. The default mapping is as follows:
+ * - On**Create**Data, On**Update**Data, On**Replace**Data and On**Delete**Data all trigger On**Update**Data in the synchronized relations.
+ * - On**BeforeCreate**Data, On**BeforeUpdate**Data, On**BeforeReplace**Data and On**BeforeDelete**Data all trigger On**BeforeUpdate**Data in the synchronized relations.
+ * 
  * 
  * ## Examples
  * 
@@ -52,22 +50,23 @@ use exface\Core\CommonLogic\Debugger\LogBooks\BehaviorLogBook;
  * 
  * ```
  * 
- * @author Andrej Kabachnik
+ * @author Andrej Kabachnik, Georg Bieger
  * 
  */
-class AffectingBehavior extends AbstractBehavior
+class SynchronizingBehavior extends AbstractBehavior
 {
+    private array $affectedRelations = [];
+    
     private array $eventMapping = [];
     
     private array $eventMappingModifications = [];
     
     private array $registeredEventListeners = [];
     
-    private $inProgress = false;
+    private bool $inProgress = false;
     
     /**
      *
-     * {@inheritDoc}
      * @see \exface\Core\CommonLogic\Model\Behaviors\AbstractBehavior::registerEventListeners()
      */
     protected function registerEventListeners() : BehaviorInterface
@@ -75,11 +74,12 @@ class AffectingBehavior extends AbstractBehavior
         $eventMapping = !empty($this->eventMapping) ? $this->eventMapping : $this->getDefaultEventMapping();
         $eventMapping = array_merge($eventMapping, $this->eventMappingModifications);
         $this->validateEventMapping($eventMapping);
+        $getEventName = 'getEventName';
         
         if (! empty($eventMapping)) {
             $eventMgr = $this->getWorkbench()->eventManager();
             foreach ($eventMapping as $fromEvent => $toEvent) {
-                $eventMgr->addListener($fromEvent, [$this, 'onEventRelay'], $this->getPriority());
+                $eventMgr->addListener($fromEvent::$getEventName(), [$this, 'onEventRelay'], $this->getPriority());
                 $this->registeredEventListeners[$fromEvent] = $toEvent;
             }
         }
@@ -89,15 +89,16 @@ class AffectingBehavior extends AbstractBehavior
     
     /**
      *
-     * {@inheritDoc}
      * @see \exface\Core\CommonLogic\Model\Behaviors\AbstractBehavior::unregisterEventListeners()
      */
     protected function unregisterEventListeners() : BehaviorInterface
     {
         $eventMgr = $this->getWorkbench()->eventManager();
+        $getEventName = 'getEventName';
+        
         if (! empty($this->registeredEventListeners)) {
             foreach ($this->registeredEventListeners as $fromEvent => $toEvent) {
-                $eventMgr->removeListener($fromEvent, [$this, 'onEventRelay']);
+                $eventMgr->removeListener($fromEvent::$getEventName(), [$this, 'onEventRelay']);
             }
         }
         
@@ -138,8 +139,8 @@ class AffectingBehavior extends AbstractBehavior
 
     /**
      * Executes the action if applicable
-     * 
-     * @param EventInterface $event
+     *
+     * @param AbstractDataSheetEvent $event
      * @return void
      */
     public function onEventRelay(AbstractDataSheetEvent $event) : void
@@ -149,6 +150,10 @@ class AffectingBehavior extends AbstractBehavior
         }
         
         $inputSheet = $event->getDataSheet();
+        // Ignore empty sheets - nothing to calculate here!
+        if ($inputSheet->isEmpty()) {
+            return;
+        }
         
         // Do not do anything, if the base object of the widget is not the object with the behavior and is not
         // extended from it.
@@ -172,41 +177,34 @@ class AffectingBehavior extends AbstractBehavior
             $eventManager->dispatch(new OnBehaviorAppliedEvent($this, $event, $logbook));
             return;
         }
-
-        // Ignore empty sheets - nothing to calculate here!
-        if ($inputSheet->isEmpty()) {
-            return;
-        }
-
         $this->inProgress = true;
+        
         foreach ($this->getAffectedRelationPaths() as $relationString) {
             $relPath = RelationPathFactory::createFromString($this->getObject(), $relationString);
             $targetObject = $relPath->getEndObject();
-            // TODO trigger event for target object. We need to create a DataSheet that will have the UIDs
-            // of the target object instances. E.g. for ORDER_POS original UpdateData we need to find all
-            // UIDs of ORDERs (read the ORDER column of the original event data) and create a DataSheet
-            // for the object ORDER, give it the UID
             $targetSheet = DataSheetFactory::createFromObject($targetObject);
             $targetSheet->getColumns()->addFromSystemAttributes();
-            // TODO check if inputSheet has the required columns! May need to read them first. But this
-            // will only work if we have a UID column
-            $targetUids = $inputSheet->getColumns()->getByExpression($relationString)->getValues();
 
-            // Read the target data first?
+            if(!$relUidCol = $inputSheet->getColumns()->getByExpression($relationString)) {
+                $relSheet = $inputSheet->copy();
+                $relSheet->getFilters()->addConditionFromColumnValues($relSheet->getUidColumn());
+                $relUidCol = $relSheet->getColumns()->addFromExpression($relationString);
+                $relSheet->dataRead();
+            }
+
+            $targetUids = $relUidCol->getValues();
             $targetSheet->getFilters()->addConditionFromValueArray($targetSheet->getUidColumn()->getExpressionObj(), $targetUids);
             $targetSheet->dataRead();
 
-            // Now we have an empty data sheet with just the UID column filled.
-            // TODO trigger the event
-            $eventType = $this->eventMapping[get_class($event)];
+            $eventType = $this->getActiveEventMapping()[get_class($event)];
             if($eventType === null) {
                 throw new BehaviorConfigurationError($this, "Could not relay update to ".$targetObject.", because no valid event mapping was found for ".get_class($event)."!");
             }
             
-            $eventManager->dispatch(new $eventType($event->getDataSheet(), $event->getTransaction()));
+            $eventManager->dispatch(new $eventType($targetSheet, $event->getTransaction()));
         }
-        $this->inProgress = false;
 
+        $this->inProgress = false;
         $this->getWorkbench()->eventManager()->dispatch(new OnBehaviorAppliedEvent($this, $event, $logbook));
     }
 
@@ -222,11 +220,11 @@ class AffectingBehavior extends AbstractBehavior
      * @uxon-type metamodel:relation[]
      * @uxon-template [""]
      * 
-     * @return \exface\Core\Behaviors\AffectingBehavior
+     * @return \exface\Core\Behaviors\SynchronizingBehavior
      */
-    public function setChangesAffectRelations(UxonObject $arrayOfRelationPaths) : AffectingBehavior
+    public function setChangesAffectRelations(UxonObject $arrayOfRelationPaths) : SynchronizingBehavior
     {
-        $this->relations = $arrayOfRelationPaths->toArray();
+        $this->affectedRelations = $arrayOfRelationPaths->toArray();
 
         /* IDEA mark related attributes as system to check ORDER timestamp when saving ORDER_POS.
          * Will probably not work yet because system attributes are only direct ones.
@@ -252,11 +250,10 @@ class AffectingBehavior extends AbstractBehavior
      * {@inheritDoc}
      * @see \exface\Core\CommonLogic\Model\Behaviors\AbstractBehavior::exportUxonObject()
      */
-    public function exportUxonObject()
+    public function exportUxonObject() : UxonObject
     {
-        $uxon = parent::exportUxonObject();
         // TODO
-        return $uxon;
+        return parent::exportUxonObject();
     }
 
     /**
@@ -265,7 +262,15 @@ class AffectingBehavior extends AbstractBehavior
      */
     protected function getAffectedRelationPaths() : array
     {
-        return $this->relations;
+        return $this->affectedRelations;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getActiveEventMapping() : array
+    {
+        return !empty($this->registeredEventListeners) ? $this->registeredEventListeners : $this->getDefaultEventMapping();
     }
 
     /**
@@ -339,13 +344,13 @@ class AffectingBehavior extends AbstractBehavior
     {
         return [
             OnCreateDataEvent::class => OnUpdateDataEvent::class,
-            OnBeforeCreateDataEvent::class => OnBeforeCreateDataEvent::class,
+            OnBeforeCreateDataEvent::class => OnBeforeUpdateDataEvent::class,
             OnUpdateDataEvent::class => OnUpdateDataEvent::class,
-            OnBeforeUpdateDataEvent::class => OnBeforeCreateDataEvent::class,
+            OnBeforeUpdateDataEvent::class => OnBeforeUpdateDataEvent::class,
             OnReplaceDataEvent::class => OnUpdateDataEvent::class,
             OnBeforeReplaceDataEvent::class => OnBeforeUpdateDataEvent::class,
             OnDeleteDataEvent::class => OnUpdateDataEvent::class,
-            OnBeforeDeleteDataEvent::class => OnBeforeCreateDataEvent::class
+            OnBeforeDeleteDataEvent::class => OnBeforeUpdateDataEvent::class
         ];
     }
 }

--- a/CommonLogic/AbstractAction.php
+++ b/CommonLogic/AbstractAction.php
@@ -2,8 +2,8 @@
 namespace exface\Core\CommonLogic;
 
 use exface\Core\Factories\WidgetFactory;
-use exface\Core\Factories\WidgetLinkFactory;
 use exface\Core\Interfaces\DataSheets\DataSheetInterface;
+use exface\Core\Interfaces\Model\IAffectMetaObjectsInterface;
 use exface\Core\Interfaces\Model\MetaObjectInterface;
 use exface\Core\Interfaces\Actions\iCanBeUndone;
 use exface\Core\Factories\DataSheetFactory;
@@ -1432,6 +1432,17 @@ abstract class AbstractAction implements ActionInterface
         if ($this instanceof iModifyData) {
             $effects = array_merge($effects,  $this->getEffectsFromModel());
         }
+        
+        foreach ($this->getMetaObject()->getBehaviors() as $behavior) {
+            if($behavior instanceof IAffectMetaObjectsInterface) {
+                foreach ($behavior->getAffectedMetaObjects() as $affectedMetaObject) {
+                    $effects[] = new ActionEffect($this, new UxonObject([
+                        'effected_object' => $affectedMetaObject->getAliasWithNamespace()
+                    ]));
+                }
+            }
+        }
+        
         return $effects;
     }
     

--- a/Interfaces/Model/IAffectMetaObjectsInterface.php
+++ b/Interfaces/Model/IAffectMetaObjectsInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace exface\Core\Interfaces\Model;
+
+use exface\Core\CommonLogic\AbstractAction;
+
+/**
+ * Implement this interface to signal that instances of this class may affect the state of certain MetaObjects.
+ * 
+ * @see MetaObjectInterface, AbstractAction
+ */
+interface IAffectMetaObjectsInterface
+{
+    /**
+     * Retrieve all MetaObjects affected by this instance.
+     * 
+     * @return MetaObjectInterface[]
+     */
+    public function getAffectedMetaObjects() : array;
+}


### PR DESCRIPTION
### Notes
- Had to extend `AbstractWidget`&rarr;`getEffects()` to enable refreshing pages, when parent objects are updated. This may introduce unwanted coupling and should be discussed.
- When a child object is open in an editor in one browser tab and deleted in another tab, the editor tab save button will throw an error. While this is correct, it may indicate some usability issues.  