### PR TITLE
FIX DataCheck adjusted exception handling

### DIFF
--- a/CommonLogic/DataSheets/DataCheck.php
+++ b/CommonLogic/DataSheets/DataCheck.php
@@ -112,7 +112,8 @@ class DataCheck implements DataCheckInterface
         try {
             return $data->extract($filter, true);
         } catch (DataSheetExtractError $e) {
-            throw new DataCheckNotApplicableError($data, 'Cannot validate data: information required for conditions is not available in the data sheet!', null, $e);
+            // Since the data extraction failed, we can assume that the check does not apply.
+            return $data->copy()->removeRows();
         }
     }
     

--- a/Exceptions/DataSheets/DataCheckNotApplicableError.php
+++ b/Exceptions/DataSheets/DataCheckNotApplicableError.php
@@ -7,7 +7,7 @@ namespace exface\Core\Exceptions\DataSheets;
  * @author Andrej Kabachnik
  *
  */
-class DataCheckNotApplicableError extends DataCheckFailedError
+class DataCheckNotApplicableError extends DataCheckRuntimeError
 {
     
 }


### PR DESCRIPTION
### DataCheckNotApplicableError
- Changed base class from `DataCheckFailedError` to `DataCheckRuntimeError`
- `DataCheckFailedError` is used to signal, that the data check **did apply** to the data in question.  The above fix prevents incompatible data from being treated as positives,

### DataCheck
- `findViolationsViaFilter()` no longer throws `DataSheetNotApplicableError`
- If the data required for the check is not present in the sheet, the check does not apply. This situation does not indicate any programmatic or configuration errors and should therefore not trigger an unhandled exception.