### PR TITLE
NEW Condition added makeExplicit() 

### DIFF
--- a/CommonLogic/Model/Condition.php
+++ b/CommonLogic/Model/Condition.php
@@ -845,7 +845,18 @@ class Condition implements ConditionInterface
      */
     public function isExplicit() : bool
     {
-        return empty($this->getValue()) || ComparatorDataType::isExplicit($this->getComparator());
+        if($this->isEmpty()) {
+            return true;
+        }
+        
+        $values = $this->getValue();
+        if(!is_array($values)) {
+            $expression = $this->getExpression();
+            $delimiter = $expression->isMetaAttribute() ? $expression->getAttribute()->getValueListDelimiter() : ',';
+            $values = explode($delimiter, $values);
+        }
+        
+        return count($values) <= 1 || ComparatorDataType::isExplicit($this->getComparator());
     }
 
     /**

--- a/CommonLogic/QueryBuilder/QueryPartFilterGroup.php
+++ b/CommonLogic/QueryBuilder/QueryPartFilterGroup.php
@@ -53,14 +53,20 @@ class QueryPartFilterGroup extends QueryPart implements iCanBeCopied
     /**
      * Creates a filter from a given condition object, adds it to the group and returns the resulting query part.
      *
-     * @param Condition $condition            
-     * @return QueryPartFilter
+     * @param Condition $condition
+     * @return QueryPartFilter|QueryPartFilterGroup
      */
-    public function addCondition(Condition $condition)
+    public function addCondition(Condition $condition): QueryPartFilter|QueryPartFilterGroup
     {
-        $qpart = $this::createQueryPartFromCondition($condition, $this->getQuery());
-        $this->addFilter($qpart);
-        return $qpart;
+        if($condition->isExplicit()) {
+            $qPart = $this::createQueryPartFromCondition($condition, $this->getQuery());
+            $this->addFilter($qPart);
+        } else {
+            $qPart = $this::createQueryPartFromConditionGroup($condition->makeExplicit(), $this->getQuery());
+            $this->addNestedGroup($qPart);
+        }
+        
+        return $qPart;
     }
 
     /**


### PR DESCRIPTION
### Notes
- This is just an exploratory change. `ComparatorDataType` turned out to have inconsistent syntax, which will have to be redesigned in the future. The current implementation mostly serves to test filters with multi-select support.
- `ComparatorDataType` uses very verbose switch-cases for analyzing comparators that could be replaced with simpler string analysis. For example `isListComparator` could be covered by `isExplicit`. Is this intended?
- At the moment `QueryFilterGroup` handles the conversion to explicit conditions. That is probably incorrect, where should we actually implement this transformation? Maybe `AbstractQueryBuilder` to allow specific query builders to decide for themselves whether they want to make a condition explicit? 