### PR TITLE
NEW Implemented native JSON support

### DIFF
--- a/Behaviors/CustomAttributesJsonBehavior.php
+++ b/Behaviors/CustomAttributesJsonBehavior.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace exface\Core\Behaviors;
+
+use exface\Core\CommonLogic\Debugger\LogBooks\BehaviorLogBook;
+use exface\Core\CommonLogic\Model\Behaviors\AbstractBehavior;
+use exface\Core\DataTypes\StringDataType;
+use exface\Core\Events\Behavior\OnBeforeBehaviorAppliedEvent;
+use exface\Core\Events\Behavior\OnBehaviorAppliedEvent;
+use exface\Core\Events\Model\OnMetaObjectLoadedEvent;
+use exface\Core\Exceptions\Behaviors\BehaviorRuntimeError;
+use exface\Core\Exceptions\Model\MetaAttributeNotFoundError;
+use exface\Core\Factories\DataSheetFactory;
+use exface\Core\Factories\DataTypeFactory;
+use exface\Core\Factories\MetaObjectFactory;
+use exface\Core\Interfaces\Model\BehaviorInterface;
+
+/**
+ * Automatically adds custom attributes to the object, whenever it is loaded from into memory.
+ *
+ * ### Design Considerations
+ *
+ * 1. Somebody defines a CA (CustomAttribute)
+ *      - this can happen anywhere in PUI
+ *      - Nobody will know this has happened (by default)
+ *      - &rarr; We need a central CONFIG that stores and exposes these definitions
+ * 2. Object is loaded into memory
+ *      - this may happen without loading its data
+ *      - we need to add any CAs to the object at this point to ensure designers and users can understand them
+ *      - &rarr; We need to load CA info from the central DEFINITION
+ *
+ * **Question:** Where should we store the CA DEFINITION?
+ *
+ * - **Explicit:** Add an JSON column to the MetaObject table, that stores CA structure per MetaObject directly.
+ * Clean from a PUI perspective, but messy in terms of maintenance and separation of concerns.
+ * - **Implicit:** CA structure is derived from actual data [ row -> JSON-Colum (data and structure)]
+ * Clean in terms of maintenance and separation of concerns, but requires loading data whenever we wish to
+ * reason about CA structure. It is also difficult to deduce the structure, since data may be incomplete.
+ * - **Table:** Create a special table PER PROJECT, where CA structure is stored like [ MetaObjectId -> CA Definitions
+ * ]. We need to discuss pros and cons for this one.
+ * - Any other options?
+ */
+class CustomAttributesJsonBehavior extends AbstractBehavior
+{
+    private bool $processed = false;
+
+    private ?string $jsonDefinitionObjectAlias = null;
+
+    private ?string $jsonDefinitionAttributeAlias = null;
+
+    protected function registerEventListeners(): BehaviorInterface
+    {
+        $this->getWorkbench()->eventManager()->addListener(
+            OnMetaObjectLoadedEvent::getEventName(),
+            [$this,'onLoadedAddCustomAttributes'],
+            $this->getPriority())
+        ;
+
+        return $this;
+    }
+
+    protected function unregisterEventListeners(): BehaviorInterface
+    {
+        $this->getWorkbench()->eventManager()->removeListener(
+            OnMetaObjectLoadedEvent::getEventName(),
+            [$this,'onLoadedAddCustomAttributes']
+        );
+
+        return $this;
+    }
+    public function onLoadedAddCustomAttributes(OnMetaObjectLoadedEvent $event) : void
+    {
+        if($this->isDisabled() || $this->processed) {
+            return;
+        }
+        $this->processed = true;
+
+        $logBook = new BehaviorLogBook($this->getAlias(), $this, $event);
+        $logBook->addLine('Object loaded, checking for custom attributes...');
+
+        $this->getWorkbench()->eventManager()->dispatch(new OnBeforeBehaviorAppliedEvent($this, $event, $logBook));
+
+        $customAttributes = $this->loadAttributesFromDefinition($logBook);
+        $this->addAttributes($customAttributes, $logBook);
+
+        $this->getWorkbench()->eventManager()->dispatch(new OnBehaviorAppliedEvent($this, $event, $logBook));
+    }
+
+    protected function loadAttributesFromData(BehaviorLogBook $logBook): array
+    {
+        if( empty($this->getJsonDefinitionAttributeAlias()) ) {
+            return [];
+        }
+        
+        $definitionObjectAlias = $this->getJsonDefinitionObjectAlias() ?? $this->getObject()->getAliasWithNamespace();
+        
+        if(!$this->getObject()->isExactly($definitionObjectAlias)) {
+            return $this->loadAttributesFromDefinition($logBook);
+        }
+
+        try {
+            $dataSheet = DataSheetFactory::createFromObjectIdOrAlias($this->getWorkbench(), $this->getObject());
+            $jsonAttribute = $this->getObject()->getAttribute($this->getJsonDefinitionAttributeAlias());
+        } catch (MetaAttributeNotFoundError $error) {
+            throw new BehaviorRuntimeError($this, 'Cannot load custom attributes.', null, $error, $logBook);
+        }
+
+        $dataAddress = $jsonAttribute->getDataAddress();
+        $dataSheet->getColumns()->addFromAttribute($jsonAttribute);
+        $dataSheet->dataRead();
+
+        $customAttributes = [];
+        foreach ($dataSheet->getColumnValues($this->getJsonDefinitionAttributeAlias()) as $json) {
+            if(empty($json) || $json === '{}') {
+                continue;
+            }
+
+            foreach (json_decode($json) as $attribute => $value) {
+                if(key_exists($attribute, $customAttributes)) {
+                    continue;
+                }
+
+                $customAttributes[$attribute] = $dataAddress . '::$.' . $attribute;
+            }
+        }
+
+        return $customAttributes;
+    }
+    
+    protected function loadAttributesFromDefinition(BehaviorLogBook $logBook) : array
+    {
+        if( empty($this->getJsonDefinitionAttributeAlias()) || empty($this->getJsonDefinitionObjectAlias()) ) {
+            return [];
+        }
+
+        $dataSheet = DataSheetFactory::createFromObjectIdOrAlias($this->getWorkbench(), $this->getJsonDefinitionObjectAlias());
+        $object = $dataSheet->getMetaObject();
+
+        try {
+            $jsonAttribute = $object->getAttribute($this->getJsonDefinitionAttributeAlias());
+        } catch (MetaAttributeNotFoundError $error) {
+            throw new BehaviorRuntimeError($this, 'Cannot load custom attributes.', null, $error, $logBook);
+        }
+
+        $dataAddress = $jsonAttribute->getDataAddress();
+        $dataSheet->getColumns()->addFromAttribute($jsonAttribute);
+        $dataSheet->getColumns()->addFromUidAttribute();
+        $dataSheet->getFilters()->addConditionFromAttribute($dataSheet->getUidColumn()->getAttribute(), $object->getId());
+        $dataSheet->dataRead();
+
+        $customAttributes = [];
+        foreach ($dataSheet->getColumnValues($this->getJsonDefinitionAttributeAlias()) as $json) {
+            if(empty($json) || $json === '{}') {
+                continue;
+            }
+
+            foreach (json_decode($json) as $attribute => $value) {
+                if(key_exists($attribute, $customAttributes)) {
+                    continue;
+                }
+
+                $customAttributes[$attribute] = $dataAddress . '::$.' . $attribute;
+            }
+        }
+
+        return $customAttributes;
+    }
+
+    protected function addAttributes(array $customAttributes, BehaviorLogBook $logBook) : void
+    {
+        $dataType = DataTypeFactory::createFromString($this->getWorkbench(), StringDataType::class);
+        foreach ($customAttributes as $alias => $address) {
+            $attribute = MetaObjectFactory::addAttributeTemporary(
+                $this->getObject(), 
+                $alias, 
+                $alias, 
+                $address, 
+                $dataType);
+            
+            $attribute->setFilterable(true);
+            $attribute->setSortable(true);
+        }
+    }
+
+    /**
+     * @uxon-property json_definition_object_alias
+     * @uxon-type metamodel:object
+     *
+     * @param string|null $alias
+     * @return CustomAttributesJsonBehavior
+     */
+    public function setJsonDefinitionObjectAlias(?string $alias) : CustomAttributesJsonBehavior
+    {
+        $this->jsonDefinitionObjectAlias = $alias;
+        return $this;
+    }
+
+    public function getJsonDefinitionObjectAlias() : ?string
+    {
+        return $this->jsonDefinitionObjectAlias;
+    }
+
+    /**
+     * @uxon-property json_definition_attribute_alias
+     * @uxon-type metamodel:attribute
+     *
+     * @param string|null $alias
+     * @return CustomAttributesJsonBehavior
+     */
+    public function setJsonDefinitionAttributeAlias(?string $alias) : CustomAttributesJsonBehavior
+    {
+        $this->jsonDefinitionAttributeAlias = $alias;
+        return $this;
+    }
+
+    public function getJsonDefinitionAttributeAlias() : ?string
+    {
+        return $this->jsonDefinitionAttributeAlias;
+    }
+}

--- a/Behaviors/CustomAttributesJsonBehavior.php
+++ b/Behaviors/CustomAttributesJsonBehavior.php
@@ -138,7 +138,7 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
             $dataAddress = $jsonAttribute->getDataAddress();
             $logBook->addLine('Generated data address: "' . $dataAddress . '".');
 
-            if($ownerAttributeAlias = $this->getOwnerAttributeAlias()) {
+            if($ownerAttributeAlias = $this->getDefinitionOwnerAttributeAlias()) {
                 $logBook->addLine('Owner attribute alias: "' . $ownerAttributeAlias . '".');
                 $ownerAttribute = $definitionObject->getAttribute($ownerAttributeAlias);
                 $dataSheet->getColumns()->addFromAttribute($ownerAttribute);
@@ -243,12 +243,13 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
      * 
      * @uxon-property definition_object_alias
      * @uxon-type metamodel:object
-     *
+     * 
      * @param string|null $alias
      * @return CustomAttributesJsonBehavior
      */
     public function setDefinitionObjectAlias(?string $alias) : CustomAttributesJsonBehavior
     {
+        
         $this->jsonDefinitionObjectAlias = $alias;
         return $this;
     }
@@ -265,7 +266,7 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
      * 
      * @uxon-property definition_attribute_alias
      * @uxon-type metamodel:attribute
-     *
+     * 
      * @param string|null $alias
      * @return CustomAttributesJsonBehavior
      */
@@ -314,7 +315,7 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
      * 
      * @uxon-property definition_owner_attribute_alias
      * @uxon-type metamodel:attribute
-     *
+     * 
      * @param string|null $alias
      * @return $this
      */

--- a/Behaviors/CustomAttributesJsonBehavior.php
+++ b/Behaviors/CustomAttributesJsonBehavior.php
@@ -17,26 +17,29 @@ use exface\Core\Interfaces\Model\BehaviorInterface;
 
 /**
  * Automatically adds custom attributes to the object, whenever it is loaded from into memory.
- *
+ * 
  * ### Usage Modes
- *
- * The current implementation supports loading CA definitions from three different sources, depending on the
+ * 
+ * The current implementation supports loading custom attribute definitions from three different sources, depending on the
  * configuration of this behavior:
+ * 
  * 1. **From Data (implicit):** If you do not define a value for `definition_object_alias` the behavior will instead try to
- * deduce its custom attribute definitions from the data stored in the data address of `json_attribute_alias`. This required loading and parsing 
+ * deduce its custom attribute definitions from the data stored in the data address of `json_attribute_alias`. This requires loading and parsing 
  * the entire data set, which is very slow. NOT RECOMMENDED.
+ * 
  * 2. **From an exclusive definition table (explicit):** If you define a value for `definition_object_alias` and `definition_attribute_alias`, 
- * but leave `owner_attribute_alias` undefined, the behavior will assume that you provided a specialized table that only contains
+ * but leave `definition_owner_attribute_alias` undefined, the behavior will assume that you provided a specialized table that only contains
  * custom attribute definitions for the object it is attached to. This is very fast, but requires you to set up an exclusive table for
  * this MetaObject. RECOMMENDED.
- * 3. **From a general definition table (explicit):** If you also define a value for `owner_attribute_alias`, the behavior will assume that you
+ * 
+ * 3. **From a general definition table (explicit):** If you also define a value for `definition_owner_attribute_alias`, the behavior will assume that you
  * provided a general definition table that contains custom attribute definitions for any number of MetaObjects. This is reasonably fast and requires
  * little setup. RECOMMENDED.
  * 
  * ### TO DOs
  * 
  * - The DataType of all JSON-Attributes is hard-coded to be `Text`. We should update this with an option to load a data-type from the definition.
- * - If `definition_object_alias` references an object, that has itself a custom attributes behavior will cause an error to be thrown.
+ * - If `definition_object_alias` references an object, that has itself a custom attributes behavior an error will be thrown.
  * In rare cases this might even result in infinite recursion. This happens, because the object referenced in `definition_object_alias` must be
  * loaded into memory, which in turn would trigger a new instance of this behavior.
  * TODO geb 2025-27-01: How to properly guard against this? (Idea: Static list?)
@@ -49,7 +52,7 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
 
     private ?string $jsonDefinitionAttributeAlias = null;
     private string $jsonAttributeAlias;
-    private ?string $ownerAttributeAlias = null;
+    private ?string $definitionOwnerAttributeAlias = null;
 
     protected function registerEventListeners(): BehaviorInterface
     {
@@ -236,6 +239,8 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
     }
 
     /**
+     * Define from which object this behavior should try to load its custom attribute definitions.
+     * 
      * @uxon-property definition_object_alias
      * @uxon-type metamodel:object
      *
@@ -254,6 +259,10 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
     }
 
     /**
+     * Define the attribute where the actual definition for each custom attribute can be found.
+     * 
+     * This attribute belongs to the object identified with `definition_object_alias`.
+     * 
      * @uxon-property definition_attribute_alias
      * @uxon-type metamodel:attribute
      *
@@ -272,6 +281,10 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
     }
 
     /**
+     * Define the attribute alias where the actual JSON data is stored. 
+     * 
+     * This attribute belongs to the object this behavior is attached to.
+     * 
      * @uxon-property json_attribute_alias 
      * @uxon-type metamodel:attribute
      * 
@@ -290,20 +303,29 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
     }
 
     /**
-     * @uxon-property owner_attribute_alias
+     * Define the attribute alias used to store the owner of a custom attribute definition. 
+     * 
+     * This attribute belongs to the object identified with `definition_object_alias`.
+     * If you want to store custom attribute definitions for multiple meta objects
+     * in the same table, you need to assign a value to this property.
+     * Ignore this property if you have separate definition tables for each meta object.
+     * 
+     * Default value is `""` (NULL).
+     * 
+     * @uxon-property definition_owner_attribute_alias
      * @uxon-type metamodel:attribute
      *
      * @param string|null $alias
      * @return $this
      */
-    public function setOwnerAttributeAlias(?string $alias) : CustomAttributesJsonBehavior
+    public function setDefinitionOwnerAttributeAlias(?string $alias) : CustomAttributesJsonBehavior
     {
-        $this->ownerAttributeAlias = $alias;
+        $this->definitionOwnerAttributeAlias = $alias;
         return $this;
     }
     
-    public function getOwnerAttributeAlias() : ?string
+    public function getDefinitionOwnerAttributeAlias() : ?string
     {
-        return $this->ownerAttributeAlias;
+        return $this->definitionOwnerAttributeAlias;
     }
 }

--- a/QueryBuilders/AbstractSqlBuilder.php
+++ b/QueryBuilders/AbstractSqlBuilder.php
@@ -1141,41 +1141,6 @@ abstract class AbstractSqlBuilder extends AbstractQueryBuilder
         
         return new DataQueryResultData([], $affected_rows ?? 0);
     }
-
-    /**
-     * Builds an inline SQL-Snippet that encodes the provided key value pairs as JSON, using
-     * only native SQL functions of the corresponding dialect.
-     *
-     * - Keys must be strings, matching the following pattern: `$.key`.
-     * - This function can only generate a JSON that is exactly 1 level deep. Keys that try to access
-     * deeper levels (e.g. `$.allowed.forbidden`) will not function properly.
-     *
-     * NOTE: JSON manipulation may not be fully supported by all dialects. In that case this function returns
-     * a json_encoded string. 
-     * 
-     * TODO geb 2025-01-21: We might need a better default implementation.
-     *
-     * @param array  $keyValuePairs
-     * @param string $initialJson
-     * @return string
-     */
-    protected function buildSqlEncodeAsJsonFlat(array $keyValuePairs, string $initialJson = "'{}'") : string
-    {
-        return json_encode($keyValuePairs);
-    }
-
-    /**
-     * Build an inline SQL-Snippet that generates an initial JSON value for native JSON-Functions.
-     * 
-     * NOTE: JSON manipulation may not be fully supported by all dialects. In that case this function returns `'{}'`.
-     * 
-     * @param string $columnName
-     * @return string
-     */
-    protected function buildSqlInitialJson(string $columnName) : string
-    {
-        return '{}';
-    }
     
     /**
      * Splits the a seta of query parts of the current query into multiple separate queries, each of them containing only query
@@ -3283,7 +3248,42 @@ abstract class AbstractSqlBuilder extends AbstractQueryBuilder
      */
     protected function buildSqlJsonRead(string $address, string $jsonPath) : string
     {
-        return "JSON_VALUE({$address}, '{$jsonPath}')";
+        return "JSON_VALUE({$this->buildSqlInitialJson($address)}, '{$jsonPath}')";
+    }
+
+    /**
+     * Builds an inline SQL-Snippet that encodes the provided key value pairs as JSON, using
+     * only native SQL functions of the corresponding dialect.
+     *
+     * - Keys must be strings, matching the following pattern: `$.key`.
+     * - This function can only generate a JSON that is exactly 1 level deep. Keys that try to access
+     * deeper levels (e.g. `$.allowed.forbidden`) will not function properly.
+     *
+     * NOTE: JSON manipulation may not be fully supported by all dialects. In that case this function returns
+     * a json_encoded string.
+     *
+     * TODO geb 2025-01-21: We might need a better default implementation.
+     *
+     * @param array  $keyValuePairs
+     * @param string $initialJson
+     * @return string
+     */
+    protected function buildSqlEncodeAsJsonFlat(array $keyValuePairs, string $initialJson = "'{}'") : string
+    {
+        return json_encode($keyValuePairs);
+    }
+
+    /**
+     * Build an inline SQL-Snippet that generates an initial JSON value for native JSON-Functions.
+     *
+     * NOTE: JSON manipulation may not be fully supported by all dialects. In that case this function returns `'{}'`.
+     *
+     * @param string $columnName
+     * @return string
+     */
+    protected function buildSqlInitialJson(string $columnName) : string
+    {
+        return '{}';
     }
 
     /**

--- a/QueryBuilders/MsSqlBuilder.php
+++ b/QueryBuilders/MsSqlBuilder.php
@@ -826,7 +826,7 @@ class MsSqlBuilder extends AbstractSqlBuilder
         return <<<SQL
 
 CASE 
-    WHEN {$columnName} IS NOT NULL AND ISJSON({$columnName})
+    WHEN {$columnName} IS NOT NULL AND ISJSON({$columnName}) > 0
     THEN {$columnName}
     ELSE '{}'
 END 

--- a/QueryBuilders/MsSqlBuilder.php
+++ b/QueryBuilders/MsSqlBuilder.php
@@ -803,4 +803,33 @@ class MsSqlBuilder extends AbstractSqlBuilder
         
         return true;
     }
+
+    /**
+     * @inheritdoc 
+     */
+    protected function buildSqlEncodeAsJsonFlat(array $keyValuePairs, string $initialJson = "'{}'"): string
+    {
+        $resultJson = $initialJson;
+
+        foreach ($keyValuePairs as $attributePath => $attributeValue) {
+            $resultJson = "JSON_MODIFY(" . $resultJson . ", '" . $attributePath . "', " . $attributeValue . ")";
+        }
+
+        return $resultJson;
+    }
+
+    /**
+     * @inheritdoc 
+     */
+    protected function buildSqlInitialJson(string $columnName): string
+    {
+        return <<<SQL
+
+CASE 
+    WHEN {$columnName} IS NOT NULL AND ISJSON({$columnName})
+    THEN {$columnName}
+    ELSE '{}'
+END 
+SQL;
+    }
 }

--- a/QueryBuilders/MySqlBuilder.php
+++ b/QueryBuilders/MySqlBuilder.php
@@ -438,4 +438,33 @@ class MySqlBuilder extends AbstractSqlBuilder
         
         return new DataQueryResultData([], $cnt);
     }
+
+    /**
+     * @inheritdoc 
+     */
+    protected function buildSqlEncodeAsJsonFlat(array $keyValuePairs, string $initialJson = "'{}'"): string
+    {
+        $resultJson = $initialJson;
+
+        foreach ($keyValuePairs as $attributePath => $attributeValue) {
+            $resultJson = "JSON_SET(" . $resultJson . ", '" . $attributePath . "', " . $attributeValue . ")";
+        }
+
+        return $resultJson;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function buildSqlInitialJson(string $columnName): string
+    {
+        return <<<SQL
+
+CASE 
+    WHEN {$columnName} IS NOT NULL AND JSON_VALID({$columnName})
+    THEN {$columnName}
+    ELSE '{}'
+END 
+SQL;
+    }
 }


### PR DESCRIPTION
- Added support to MsSQL and MySQL query builders for JSON functions
- These functions in combination with previous changes by @kabachello enable custom attributes

### Notes
- Default implementations for the functions that build the JSON statements are currently not well thought out. We should think about better defaults.
- Reading from and writing to empty JSON cells no longer causes an error, but instead treats them es empty JSON objects. While this behavior improves usability, it may hide structural issues. 