### PR TITLE
FIX Bugfix - ListDataType parse() works properly

### DIFF
--- a/DataTypes/ListDataType.php
+++ b/DataTypes/ListDataType.php
@@ -40,7 +40,7 @@ class ListDataType extends StringDataType
         $valuesType = $this->getValuesDataType();
         $vals = explode($this->getListDelimiter(), $list);
         foreach ($vals as $val) {
-            $parsedVals = $valuesType->parse(trim($val));
+            $parsedVals[] = $valuesType->parse(trim($val));
         }
         $parsed = implode($this->getListDelimiter(), $parsedVals);
         return $parsed;        


### PR DESCRIPTION
Recognized in api/dataflow/BMDB-Fortschritt-Export/1.27.4/Bauwerksflaechen-Fortschritt with error 'implode(): Argument #2 ($array) must be of type ?array, string given'