### PR TITLE
NEW CustomAttributes Preview

### DIFF
--- a/Behaviors/CustomAttributesJsonBehavior.php
+++ b/Behaviors/CustomAttributesJsonBehavior.php
@@ -20,28 +20,30 @@ use exface\Core\Interfaces\Model\BehaviorInterface;
  * 
  * ### Usage Modes
  * 
- * The current implementation supports loading custom attribute definitions from three different sources, depending on the
- * configuration of this behavior:
+ * The current implementation supports loading custom attribute definitions from three different sources, depending on
+ * the configuration of this behavior:
  * 
- * 1. **From Data (implicit):** If you do not define a value for `definition_object_alias` the behavior will instead try to
- * deduce its custom attribute definitions from the data stored in the data address of `json_attribute_alias`. This requires loading and parsing 
- * the entire data set, which is very slow. NOT RECOMMENDED.
+ * 1. **From Data (implicit):** If you do not define a value for `definition_object_alias` the behavior will instead
+ * try to deduce its custom attribute definitions from the data stored in the data address of `json_attribute_alias`.
+ * This requires loading and parsing  the entire data set, which is very slow. NOT RECOMMENDED.
  * 
- * 2. **From an exclusive definition table (explicit):** If you define a value for `definition_object_alias` and `definition_attribute_alias`, 
- * but leave `definition_owner_attribute_alias` undefined, the behavior will assume that you provided a specialized table that only contains
- * custom attribute definitions for the object it is attached to. This is very fast, but requires you to set up an exclusive table for
- * this MetaObject. RECOMMENDED.
+ * 2. **From an exclusive definition table (explicit):** If you define a value for `definition_object_alias` and
+ * `definition_attribute_alias`,  but leave `definition_owner_attribute_alias` undefined, the behavior will assume that
+ * you provided a specialized table that only contains custom attribute definitions for the object it is attached to.
+ * This is very fast, but requires you to set up an exclusive table for this MetaObject. RECOMMENDED.
  * 
- * 3. **From a general definition table (explicit):** If you also define a value for `definition_owner_attribute_alias`, the behavior will assume that you
- * provided a general definition table that contains custom attribute definitions for any number of MetaObjects. This is reasonably fast and requires
- * little setup. RECOMMENDED.
+ * 3. **From a general definition table (explicit):** If you also define a value for
+ * `definition_owner_attribute_alias`, the behavior will assume that you provided a general definition table that
+ * contains custom attribute definitions for any number of MetaObjects. This is reasonably fast and requires little
+ * setup. RECOMMENDED.
  * 
  * ### TO DOs
  * 
- * - The DataType of all JSON-Attributes is hard-coded to be `Text`. We should update this with an option to load a data-type from the definition.
- * - If `definition_object_alias` references an object, that has itself a custom attributes behavior an error will be thrown.
- * In rare cases this might even result in infinite recursion. This happens, because the object referenced in `definition_object_alias` must be
- * loaded into memory, which in turn would trigger a new instance of this behavior.
+ * - The DataType of all JSON-Attributes is hard-coded to be `Text`. We should update this with an option to load a
+ * data-type from the definition.
+ * - If `definition_object_alias` references an object, that has itself a custom attributes behavior an error will be
+ * thrown. In rare cases this might even result in infinite recursion. This happens, because the object referenced in
+ * `definition_object_alias` must be loaded into memory, which in turn would trigger a new instance of this behavior.
  * TODO geb 2025-27-01: How to properly guard against this? (Idea: Static list?)
  */
 class CustomAttributesJsonBehavior extends AbstractBehavior
@@ -50,9 +52,7 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
 
     private ?string $jsonDefinitionObjectAlias = null;
 
-    private ?string $jsonDefinitionAttributeAlias = null;
     private string $jsonAttributeAlias;
-    private ?string $definitionOwnerAttributeAlias = null;
 
     protected function registerEventListeners(): BehaviorInterface
     {
@@ -83,99 +83,96 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
      */
     public function onLoadedAddCustomAttributes(OnMetaObjectLoadedEvent $event) : void
     {
-        if($this->isDisabled() || $this->processed) {
+        if($this->isDisabled() || $this->processed || !$event->getObject()->isExactly($this->getObject())) {
             return;
         }
         $this->processed = true;
-
         $logBook = new BehaviorLogBook($this->getAlias(), $this, $event);
         $logBook->addLine('Object loaded, checking for custom attributes...');
 
         $this->getWorkbench()->eventManager()->dispatch(new OnBeforeBehaviorAppliedEvent($this, $event, $logBook));
 
-        $customAttributes = $this->loadAttributesFromDefinition($logBook);
-        $this->addAttributes($customAttributes, $logBook);
+        $definitionObjectAlias = $this->getDefinitionObjectAlias() ?? $this->getObject()->getAliasWithNamespace();
+        if($this->getObject()->isExactly($definitionObjectAlias)) {
+            $this->addAttributesFromData($logBook);
+        } else {
+            $this->addAttributesFromDefinition($logBook, $definitionObjectAlias);
+        }
 
         $this->getWorkbench()->eventManager()->dispatch(new OnBehaviorAppliedEvent($this, $event, $logBook));
     }
 
     /**
-     * Loads custom attributes from an explicit definition.
-     * 
+     * Loads custom attributes from an explicit definition as associative array `[AttributeAlias => DataAddress]`.
+     *
      * NOTE: This is the default behavior, because it is flexible and fast.
-     * 
+     *
      * @param BehaviorLogBook $logBook
+     * @param string          $definitionObjectAlias
      * @return array
      */
-    protected function loadAttributesFromDefinition(BehaviorLogBook $logBook) : array
+    protected function addAttributesFromDefinition(BehaviorLogBook $logBook, string $definitionObjectAlias) : array
     {
-        $definitionObjectAlias = $this->getDefinitionObjectAlias() ?? $this->getObject()->getAliasWithNamespace();
-        if($this->getObject()->isExactly($definitionObjectAlias)) {
-            return $this->loadAttributesFromData($logBook);
-        }
-
         $dataSheet = DataSheetFactory::createFromObjectIdOrAlias($this->getWorkbench(), $definitionObjectAlias);
         $definitionObject = $dataSheet->getMetaObject();
         
-        foreach ($definitionObject->getBehaviors() as $behavior) {
-            if($behavior instanceof CustomAttributesJsonBehavior) {
-                throw new BehaviorRuntimeError(
-                    $this, 
-                    'Loading custom attributes from objects with custom attributes is not allowed!',
-                    null, 
-                    null,
-                    $logBook);
-            }
+        if($definitionObject->getBehaviors()->findBehavior(CustomAttributesJsonBehavior::class)) {
+            throw new BehaviorRuntimeError(
+                $this,
+                'Loading custom attributes from objects with custom attributes is not allowed!',
+                null,
+                null,
+                $logBook);
+        }
+        
+        if(! $definitionBehavior = $definitionObject->getBehaviors()->findBehavior(CustomAttributeDefinitionBehavior::class)) {
+            throw new BehaviorRuntimeError(
+                $this,
+                'Could not find behavior of type "' . CustomAttributeDefinitionBehavior::class . '" on MetaObject "' . $definitionObjectAlias . '"!',
+                null,
+                null,
+                $logBook);
+        }
+        
+        if(! $definitionBehavior instanceof CustomAttributeDefinitionBehavior) {
+            return [];
         }
 
+        $targetObject = $this->getObject();
+        $customAttributes = $definitionBehavior->addCustomAttributes($targetObject, $logBook);
+        
+        if(empty($customAttributes)) {
+            return [];
+        }
+        
         try {
-            $definitionAttributeAlias = $this->getDefinitionAttributeAlias();
-            $definitionAttribute = $definitionObject->getAttribute($definitionAttributeAlias);
-            $dataSheet->getColumns()->addFromAttribute($definitionAttribute);
-            $logBook->addLine('Initialized definition attribute: "' . $definitionAttributeAlias . '".');
-
-            $jsonAttribute = $this->getObject()->getAttribute($this->getJsonAttributeAlias());
-            $dataAddress = $jsonAttribute->getDataAddress();
-            $logBook->addLine('Generated data address: "' . $dataAddress . '".');
-
-            if($ownerAttributeAlias = $this->getDefinitionOwnerAttributeAlias()) {
-                $logBook->addLine('Owner attribute alias: "' . $ownerAttributeAlias . '".');
-                $ownerAttribute = $definitionObject->getAttribute($ownerAttributeAlias);
-                $dataSheet->getColumns()->addFromAttribute($ownerAttribute);
-                $dataSheet->getFilters()->addConditionFromAttribute($ownerAttribute, $this->getObject()->getAliasWithNamespace());
-                $logBook->addLine('Initialized owner attribute. Loading only attributes with "' . $ownerAttributeAlias . '" == "' . $this->getObject()->getAliasWithNamespace() . '".');
-            } else {
-                $logBook->addLine('Owner attribute undefined. Loading all attributes present in "' . $definitionObjectAlias . '".');
-            }
+            $jsonAttribute = $targetObject->getAttribute($this->getJsonAttributeAlias());
+            $dataAddressPrefix = $jsonAttribute->getDataAddress() . '::$.';
+            $logBook->addLine('Generated data address prefix: "' . $dataAddressPrefix . '".');
         } catch (MetaAttributeNotFoundError $error) {
-            throw new BehaviorRuntimeError($this, 'Cannot load custom attributes.', null, $error, $logBook);
+            throw new BehaviorRuntimeError($this, 'Cannot load custom attributes:', null, $error, $logBook);
         }
 
-        $dataSheet->dataRead();
-        $logBook->addDataSheet('Definitions', $dataSheet);
-        $logBook->addLine('Successfully loaded custom attribute definitions (see "Definitions").');
-
-        $customAttributes = [];
-        foreach ($dataSheet->getColumnValues($definitionAttributeAlias) as $customAttributeAlias) {
-            if(empty($customAttributeAlias)) {
-                continue;
-            }
-
-            $customAttributes[$customAttributeAlias] = $dataAddress . '::$.' . $customAttributeAlias;
+        $logBook->addIndent(1);
+        foreach ($customAttributes as $attribute) {
+            $alias = $attribute->getAlias();
+            $attribute->setDataAddress($dataAddressPrefix . $alias);
+            $logBook->addLine('Set data address for attribute "' . $alias . '" to "' . $attribute->getDataAddress() . '".');
         }
+        $logBook->addIndent(-1);
 
         return $customAttributes;
     }
 
     /**
-     * Deduces custom attributes from data stored in the `json_attribute_alias`.
+     * Deduces custom attributes from data stored in the `json_attribute_alias` as associative array `[AttributeAlias => DataAddress]`.
      * 
      * NOTE: This mode is very slow and is only viable as a fallback.
      * 
      * @param BehaviorLogBook $logBook
      * @return array
      */
-    protected function loadAttributesFromData(BehaviorLogBook $logBook): array
+    protected function addAttributesFromData(BehaviorLogBook $logBook): array
     {
         $logBook->addLine('"definition_object_alias" was undefined. Loading custom attribute definitions from data instead.');
         
@@ -185,11 +182,11 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
             $jsonAttribute = $this->getObject()->getAttribute($jsonAttributeAlias);
             $logBook->addLine('Initialized definition attribute: "' . $jsonAttributeAlias . '".');
             
-            $dataAddress = $jsonAttribute->getDataAddress();
+            $dataAddressPrefix = $jsonAttribute->getDataAddress() . '::$.';
             $dataSheet->getColumns()->addFromAttribute($jsonAttribute);
-            $logBook->addLine('Generated data address: "' . $dataAddress . '".');
+            $logBook->addLine('Generated data address: "' . $dataAddressPrefix . '".');
         } catch (MetaAttributeNotFoundError $error) {
-            throw new BehaviorRuntimeError($this, 'Cannot load custom attributes.', null, $error, $logBook);
+            throw new BehaviorRuntimeError($this, 'Cannot load custom attributes:', null, $error, $logBook);
         }
 
         $dataSheet->dataRead();
@@ -202,40 +199,35 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
                 continue;
             }
 
-            foreach (json_decode($json) as $attribute => $value) {
-                if(key_exists($attribute, $customAttributes)) {
+            foreach (json_decode($json) as $attributeAlias => $value) {
+                if(key_exists($attributeAlias, $customAttributes)) {
                     continue;
                 }
 
-                $customAttributes[$attribute] = $dataAddress . '::$.' . $attribute;
+                $customAttributes[$attributeAlias] = $dataAddressPrefix . $attributeAlias;
             }
         }
 
-        return $customAttributes;
-    }
-
-    /**
-     * Adds the list of attributes to the object this behavior is attached to.
-     * 
-     * @param array           $customAttributes
-     * @param BehaviorLogBook $logBook
-     * @return void
-     */
-    protected function addAttributes(array $customAttributes, BehaviorLogBook $logBook) : void
-    {
+        $logBook->addLine("Adding custom attributes...");
+        $logBook->addIndent(1);
         $dataType = DataTypeFactory::createFromString($this->getWorkbench(), StringDataType::class);
         foreach ($customAttributes as $alias => $address) {
             $logBook->addLine('Adding attribute "' . $alias . '" with data address "' . $address . '".');
             $attribute = MetaObjectFactory::addAttributeTemporary(
-                $this->getObject(), 
-                $alias, 
-                $alias, 
-                $address, 
+                $this->getObject(),
+                $alias,
+                $alias,
+                $address,
                 $dataType);
-            
+
             $attribute->setFilterable(true);
             $attribute->setSortable(true);
+            $attribute->setEditable(true);
+            $attribute->setWritable(true);
         }
+        $logBook->addIndent(-1);
+
+        return $customAttributes;
     }
 
     /**
@@ -249,7 +241,6 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
      */
     public function setDefinitionObjectAlias(?string $alias) : CustomAttributesJsonBehavior
     {
-        
         $this->jsonDefinitionObjectAlias = $alias;
         return $this;
     }
@@ -257,28 +248,6 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
     public function getDefinitionObjectAlias() : ?string
     {
         return $this->jsonDefinitionObjectAlias;
-    }
-
-    /**
-     * Define the attribute where the actual definition for each custom attribute can be found.
-     * 
-     * This attribute belongs to the object identified with `definition_object_alias`.
-     * 
-     * @uxon-property definition_attribute_alias
-     * @uxon-type metamodel:attribute
-     * 
-     * @param string|null $alias
-     * @return CustomAttributesJsonBehavior
-     */
-    public function setDefinitionAttributeAlias(?string $alias) : CustomAttributesJsonBehavior
-    {
-        $this->jsonDefinitionAttributeAlias = $alias;
-        return $this;
-    }
-
-    public function getDefinitionAttributeAlias() : ?string
-    {
-        return $this->jsonDefinitionAttributeAlias;
     }
 
     /**
@@ -301,32 +270,5 @@ class CustomAttributesJsonBehavior extends AbstractBehavior
     public function getJsonAttributeAlias() : string
     {
         return $this->jsonAttributeAlias;
-    }
-
-    /**
-     * Define the attribute alias used to store the owner of a custom attribute definition. 
-     * 
-     * This attribute belongs to the object identified with `definition_object_alias`.
-     * If you want to store custom attribute definitions for multiple meta objects
-     * in the same table, you need to assign a value to this property.
-     * Ignore this property if you have separate definition tables for each meta object.
-     * 
-     * Default value is `""` (NULL).
-     * 
-     * @uxon-property definition_owner_attribute_alias
-     * @uxon-type metamodel:attribute
-     * 
-     * @param string|null $alias
-     * @return $this
-     */
-    public function setDefinitionOwnerAttributeAlias(?string $alias) : CustomAttributesJsonBehavior
-    {
-        $this->definitionOwnerAttributeAlias = $alias;
-        return $this;
-    }
-    
-    public function getDefinitionOwnerAttributeAlias() : ?string
-    {
-        return $this->definitionOwnerAttributeAlias;
     }
 }

--- a/CommonLogic/Model/Attribute.php
+++ b/CommonLogic/Model/Attribute.php
@@ -247,6 +247,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property default_display_order
+     * @uxon-type integer
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setDefaultDisplayOrder()
@@ -267,6 +269,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property editable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setEditable()
@@ -320,6 +324,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property hidden
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setHidden()
@@ -360,6 +366,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property readable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setReadable()
@@ -381,6 +389,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property writable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setWritable()
@@ -402,6 +412,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property required
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setRequired()
@@ -422,6 +434,9 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * 
+     * @uxon-property data_type
+     * @uxon-type metamodel:datatype
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setDataAddress()
@@ -641,6 +656,9 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property default_sorter_dir
+     * @uxon-type string
+     * @uxon-template "ASC"
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setDefaultSorterDir()
@@ -909,6 +927,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property default_aggregate_function
+     * @uxon-type string
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setDefaultAggregateFunction()
@@ -933,6 +953,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property sortable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setSortable()
@@ -954,6 +976,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property filterable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setFilterable()
@@ -975,6 +999,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property aggregatable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setAggregatable()
@@ -996,6 +1022,9 @@ class Attribute implements MetaAttributeInterface
     }
     
     /**
+     * @uxon-property value_list_delimiter
+     * @uxon-type string
+     * @uxon-template ","
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setValueListDelimiter()
@@ -1205,6 +1234,8 @@ class Attribute implements MetaAttributeInterface
     }
 
     /**
+     * @uxon-property copyable
+     * @uxon-type boolean
      * 
      * {@inheritDoc}
      * @see \exface\Core\Interfaces\Model\MetaAttributeInterface::setCopyable()

--- a/CommonLogic/Traits/ImportUxonObjectTrait.php
+++ b/CommonLogic/Traits/ImportUxonObjectTrait.php
@@ -41,7 +41,6 @@ trait ImportUxonObjectTrait {
                 throw new UxonMapError($uxon, 'No setter method found for UXON property "' . $var . '" in prototype "' . get_class($this) . '"!');
             }
         }
-        return;
     }
     
     /**

--- a/Interfaces/Model/Behaviors/CustomAttributeLoaderInterface.php
+++ b/Interfaces/Model/Behaviors/CustomAttributeLoaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace exface\Core\Interfaces\Model\Behaviors;
+
+interface CustomAttributeLoaderInterface
+{
+    function getCustomAttributeDataAddressPrefix() : string;
+    function customAttributeStorageKeyToAlias(string $storageKey) : string;
+    function getCustomAttributeDataAddress(string $storageKey) : string;
+}

--- a/Interfaces/Model/Behaviors/CustomAttributeLoaderInterface.php
+++ b/Interfaces/Model/Behaviors/CustomAttributeLoaderInterface.php
@@ -4,7 +4,35 @@ namespace exface\Core\Interfaces\Model\Behaviors;
 
 interface CustomAttributeLoaderInterface
 {
+    /**
+     * Returns the data address prefix for custom attributes loaded by
+     * this behavior.
+     * 
+     * While details depend on the implementation, the data address prefix
+     * will likely consist of a regular data address suffixed with a special accessor.
+     * For example in `CustomAttributesJsonBehavior`: "json_address::$.".
+     * 
+     * @return string
+     */
     function getCustomAttributeDataAddressPrefix() : string;
+
+    /**
+     * Converts a custom attribute storage key to a matching alias.
+     * 
+     * This usually means stripping any accessors such as "$." and reducing path notations
+     * such as "some.pathTo.alias" turning into "alias".
+     * 
+     * @param string $storageKey
+     * @return string
+     */
     function customAttributeStorageKeyToAlias(string $storageKey) : string;
+
+    /**
+     * Generates a complete custom attribute data address based off of the specified
+     * storage key.
+     * 
+     * @param string $storageKey
+     * @return string
+     */
     function getCustomAttributeDataAddress(string $storageKey) : string;
 }


### PR DESCRIPTION
### Changes
- Fully functional custom attributes
- Support loading, writing and simplified type models

### Considerations
- Type models are not editor friendly, we will add dropdown support later.
- Property names for both CustomAttribute behaviors are still not final. Ideas are welcome.
- We have a quirky dependency between `CustomAttributeJsonBehavior` and `CustomAttributeDefinitionBehavior` that is currently handled via `BehaviorListInterface->findBehavior(string)` and `CustomAttributeLoaderInterface`. This feels a little wrong.
- As it stands, custom attributes cannot be translated, because `TranslatableBehavior` only searches data base entries, not virtual attributes. We might want to add support for that later down the line.