### PR TITLE
Feature/ldad 6484 expand header of an input help dialogue

### DIFF
--- a/Widgets/InputComboTable.php
+++ b/Widgets/InputComboTable.php
@@ -578,13 +578,18 @@ class InputComboTable extends InputCombo implements iTakeInputAsDataSubsheet, iC
      *
      * ATTENTION! This property will be ignored if the "lookup_action" uxon property is set.
      * This property is a shortcut for the following uxon code:
-     *
+     * 
+     * ```
+     *  {
      *      "lookup_action": {
      *           "alias": "exface.Core.ShowLookupDialog",
      *           "dialog": {
      *               "hide_header": true
      *           }
      *      }
+     *  }
+     * 
+     * ```
      *
      * @uxon-property lookup_hide_header
      * @uxon-type boolean


### PR DESCRIPTION
feat: added uxon property to InputComboTable that can set the hide st
atus of the header inside the DataLookupDialog.