### PR TITLE
NEW Trace Event for WidgetInheriter Mutations

### DIFF
--- a/CommonLogic/Mutations/AbstractMutation.php
+++ b/CommonLogic/Mutations/AbstractMutation.php
@@ -60,7 +60,7 @@ abstract class AbstractMutation implements MutationInterface, \Stringable
      * @param string $name
      * @return MutationInterface
      */
-    protected function setName(string $name) : MutationInterface
+    public function setName(string $name) : MutationInterface
     {
         $this->name = $name;
         return $this;

--- a/Events/Mutations/OnMutationsAppliedEvent.php
+++ b/Events/Mutations/OnMutationsAppliedEvent.php
@@ -15,7 +15,7 @@ class OnMutationsAppliedEvent extends AbstractEvent implements iCanGenerateDebug
     private array $mutations;
     private string $subjectName;
 
-    public function __construct(array $mutationsApplied, string $subjectName, MutationPointInterface $mutationPoint)
+    public function __construct(array $mutationsApplied, string $subjectName, MutationPointInterface $mutationPoint = null)
     {
         $this->mutationPoint = $mutationPoint;
         $this->mutations = $mutationsApplied;

--- a/Mutations/Prototypes/GenericUxonMutation.php
+++ b/Mutations/Prototypes/GenericUxonMutation.php
@@ -138,13 +138,10 @@ class GenericUxonMutation extends AbstractMutation
         }
         // remove
         foreach ($this->remove as $jsonPath) {
-            // TODO commenting out instead of removed would probably be smarter as it will not
-            // change the length of array. We could also add a comment hint about this mutation
             $jsonObj->removeObject($jsonPath);
         }
 
         $subject->replace($jsonObj->getValue());
-
         $stateAfter = $subject->toJson(true);
         return new AppliedMutation($this, $subject, $stateBefore, $stateAfter);
     }

--- a/Widgets/Parts/WidgetInheriter.php
+++ b/Widgets/Parts/WidgetInheriter.php
@@ -1,7 +1,9 @@
 <?php
 namespace exface\Core\Widgets\Parts;
 
+use exface\Core\CommonLogic\Model\UiPage;
 use exface\Core\CommonLogic\UxonObject;
+use exface\Core\Events\Mutations\OnMutationsAppliedEvent;
 use exface\Core\Interfaces\iCanBeConvertedToUxon;
 use exface\Core\Interfaces\WorkbenchDependantInterface;
 use exface\Core\CommonLogic\Traits\ImportUxonObjectTrait;
@@ -150,7 +152,11 @@ class WidgetInheriter implements WorkbenchDependantInterface, iCanBeConvertedToU
         // Apply given mutations to the extending widget
         if ($this->mutation !== null) {
             $mutation = new GenericUxonMutation($this->workbench, $this->mutation);
-            $mutation->apply($widgetUxon);
+            $mutation->setName('Widget extension mutation');
+            $applied = $mutation->apply($widgetUxon);
+            // TODO: pageUxons don't have a name in itself, is there a way to get the page name here?
+            $extensionTargetName = $widgetUxon->getProperty('name') ?? $widgetUxon->getProperty('caption');
+            $this->getWorkbench()->eventManager()->dispatch(new OnMutationsAppliedEvent([$applied], 'Widget extension mutation for UXON "' . $extensionTargetName . '"'));
         }
 
         return $widgetUxon;


### PR DESCRIPTION
had to change setName of GenericUxonMutation public so i can add a name to extension mutations.

I also removed the TODO in GeneriUxoncMutation for replace so no one else will try it again, since we agreed, that it is not beneficial.