### PR TITLE
NEW DataSpreadsheet: option to wrap column headers

### DIFF
--- a/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
@@ -313,6 +313,7 @@ JS;
         $allowDeleteRow = $this->getAllowDeleteRows() ? 'true' : 'false';
         $allowEmptyRows = $this->getAllowEmptyRows() ? 'true' : 'false';
         $wordWrap = $widget->getNowrap() ? 'false' : 'true';
+        $wrapCaptions = $this->escapeBool(!$widget->getNowrapCaptions());
         $disabledJs = $widget->isDisabled() ? 'true' : 'false';
         
         if (($widget instanceof DataSpreadSheet) && $widget->hasRowNumberAttribute()) {
@@ -361,6 +362,10 @@ JS;
 
             if (oWidget !== undefined && oWidget.isDisabled() === true) {
                 {$this->buildJsSetDisabled(true)}
+            }
+
+            if ({$wrapCaptions} === true) {
+                jqSelf.addClass('exf-wrap-captions');
             }
 
             // add hitboxes for dropdowns here once on load, as exfWidget might not be there yet

--- a/Widgets/DataImporter.php
+++ b/Widgets/DataImporter.php
@@ -153,6 +153,8 @@ class DataImporter extends AbstractWidget implements
     private $required = false;
 
     private $doNotValidateDynamically = false;
+
+    private $nowrap_captions = true;
     
     /**
      * 
@@ -213,6 +215,30 @@ class DataImporter extends AbstractWidget implements
     public function getDoNotValidateDynamically() : bool
     {
         return $this->doNotValidateDynamically;
+    }
+
+    /**
+     * Set to FALSE to allow caption text to wrap in column headers. Default is TRUE, which means text will have an overflow with ellipsis (...)
+     * 
+     * @uxon-property nowrap_captions
+     * @uxon-type boolean
+     * @uxon-default true
+     * 
+     * @param bool $value
+     * @return DataImporter
+     */
+    public function setNowrapCaptions(bool $value) : DataImporter
+    {
+        $this->nowrap_captions = $value;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getNowrapCaptions() : bool
+    {
+        return $this->nowrap_captions;
     }
     
     /**

--- a/Widgets/DataSpreadSheet.php
+++ b/Widgets/DataSpreadSheet.php
@@ -60,6 +60,8 @@ class DataSpreadSheet extends Data implements iFillEntireContainer, iTakeInputAs
     private $rowNumberColumn = null;
 
     private $doNotValidateDynamically = false;
+
+    private $nowrap_captions = true;
     
     /**
      * 
@@ -325,6 +327,30 @@ class DataSpreadSheet extends Data implements iFillEntireContainer, iTakeInputAs
     public function getDoNotValidateDynamically() : bool
     {
         return $this->doNotValidateDynamically;
+    }
+
+    /**
+     * Set to FALSE to allow caption text to wrap in column headers. Default is TRUE, which means text will have an overflow with ellipsis (...)
+     * 
+     * @uxon-property nowrap_captions
+     * @uxon-type boolean
+     * @uxon-default true
+     * 
+     * @param bool $value
+     * @return DataSpreadSheet
+     */
+    public function setNowrapCaptions(bool $value) : DataSpreadSheet
+    {
+        $this->nowrap_captions = $value;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getNowrapCaptions() : bool
+    {
+        return $this->nowrap_captions;
     }
     
     /**


### PR DESCRIPTION
- new uxon property nowrap_captions (default true, to truncate captions with '...')
- when set to false, column header captions in spreadsheets get hyphenated and wrapped when they exceed the column width
- needs styling https://github.com/ExFace/UI5Facade/pull/319 & https://github.com/ExFace/JEasyUIFacade/pull/126