### PR TITLE
NEW DataSpreadSheet/importer: rows can be striped

### DIFF
--- a/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
@@ -313,6 +313,7 @@ JS;
         $allowEmptyRows = $this->getAllowEmptyRows() ? 'true' : 'false';
         $wordWrap = $widget->getNowrap() ? 'false' : 'true';
         $wrapCaptions = $this->escapeBool(!$widget->getNowrapCaptions());
+        $stripeTable = $this->escapeBool($widget->getStriped());
         $disabledJs = $widget->isDisabled() ? 'true' : 'false';
         
         if (($widget instanceof DataSpreadSheet) && $widget->hasRowNumberAttribute()) {
@@ -364,8 +365,12 @@ JS;
                 {$this->buildJsSetDisabled(true)}
             }
 
+            // custom styling flags
             if ({$wrapCaptions} === true) {
                 jqSelf.addClass('exf-wrap-captions');
+            }
+            if ({$stripeTable} === true) {
+                jqSelf.addClass('exf-stripe-table');
             }
 
             // add hitboxes for dropdowns here once on load, as exfWidget might not be there yet

--- a/Widgets/DataImporter.php
+++ b/Widgets/DataImporter.php
@@ -166,6 +166,7 @@ class DataImporter extends AbstractWidget implements
     protected function init()
     {
         parent::init();
+        $this->setStriped(false);
         $this->initColumns();
     }
     

--- a/Widgets/DataSpreadSheet.php
+++ b/Widgets/DataSpreadSheet.php
@@ -78,6 +78,7 @@ class DataSpreadSheet extends Data implements iFillEntireContainer, iTakeInputAs
         parent::init();
         $this->setPaginate(false);
         $this->setEditable(true);
+        $this->setStriped(false);
     }
     
     /**

--- a/Widgets/Traits/DataTableTrait.php
+++ b/Widgets/Traits/DataTableTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace exface\Core\Widgets\Traits;
 
-use exface\Core\Interfaces\Widgets\iShowData;
+use exface\Core\Interfaces\Widgets\iHaveColumns;
 use exface\Core\Interfaces\Widgets\iCanWrapText;
 
 /**
@@ -57,7 +57,7 @@ trait DataTableTrait
      * @param boolean $value            
      * @return \exface\Core\Widgets\DataTable
      */
-    public function setStriped(bool $value) : iShowData
+    public function setStriped(bool $value) : iHaveColumns
     {
         $this->striped = $value;
         return $this;


### PR DESCRIPTION
- striping of dataspreadsheets can be dis/enabled with property 'striped' for better readability 
- spreadsheet headers are now styled darker to stand out visually
- disabled by default for both

needs styling https://github.com/ExFace/JEasyUIFacade/pull/128 , https://github.com/ExFace/UI5Facade/pull/327 