### PR TITLE
FIX DataSpreadsheet: dropdown hitbox no longer html element 

### DIFF
--- a/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
@@ -67,7 +67,6 @@ use exface\Core\CommonLogic\UxonObject;
  * - isDisabled() : bool
  * - refreshDropdown(iColIdx) : Promise
  * - updateDependantColumns(iColIdx, iRowIdx, mValue) : void
- * - addDropdownHitboxes(oCell): void
  * - success(data, textStatus, jqXHR)
  * - error(jqXHR, textStatus, errorThrown)
  * - bLoaded: bool // true after all constructors ran
@@ -373,24 +372,35 @@ JS;
                 jqSelf.addClass('exf-stripe-table');
             }
 
-            // add hitboxes for dropdowns here once on load, as exfWidget might not be there yet
-            // then use exfWidget.addDropdownHitboxes() to add them on subsequent onAddRow, onChange events
-            jqSelf.find(".jexcel_dropdown").each(function(){
-                if(!$(this).find(".dropdown-open").length) {
-                    $(this).prepend("<i class='dropdown-open' aria-hidden='true'></i>");
-                }
-            });
-
             // adding a custom onclick event to the table, in oder to open the editor of dropdowns with a single click
             // Idea based off https://github.com/jspreadsheet/ce/issues/1029 , 
             // as other solutions using onSelect or similar functions broke a lot of other logic, such as keyboard navigation
-            jqSelf.off('click', '.jexcel_dropdown .dropdown-open').on('click', '.jexcel_dropdown .dropdown-open', function() {
-                var iColIdx = $(this).parent(".jexcel_dropdown").data("x");
-                var iRowIdx = $(this).parent(".jexcel_dropdown").data("y");
+            // UPDATE: the originally proposed invisible <i> element showed up as table data in some cases, for example when filtering content
+            // new approach: we now listen to onclick events for the dropdown cells in general, and if they are within the 35px area from the right edge we open the editor
+            // we use a pseudo :after element to visually highlight the area, but unfortunalety pseudo elements are not truly within the dom, so we cant use onclick directly
+            jqSelf.off('click', '.jexcel_dropdown').on('click', '.jexcel_dropdown', function(e) {
+                // only open editor if were in the area around the dropdown button (35px from right side)
+                if (e.offsetX >= this.offsetWidth - 35) {
+                    var iColIdx = $(this).data("x");
+                    var iRowIdx = $(this).data("y");
 
-                if (iColIdx !== undefined && iRowIdx !== undefined) {
-                    instance.jexcel.openEditor(instance.jexcel.records[iRowIdx][iColIdx], true);
+                    if (iColIdx !== undefined && iRowIdx !== undefined) {
+                        instance.jexcel.openEditor(instance.jexcel.records[iRowIdx][iColIdx], true);
+                    }
                 }
+            });
+
+            // show hover highlight if were hovering over dropdwn area (35 px from right side), since we do not use a proper html element
+            // otherwise on hover would always be called when hovering over entire cell
+            jqSelf.off('mousemove', '.jexcel_dropdown').on('mousemove', '.jexcel_dropdown', function(e) {
+                if (e.offsetX >= this.offsetWidth - 35) {
+                    $(this).addClass('exf-dropdown-hitbox-hover');
+                } else {
+                    $(this).removeClass('exf-dropdown-hitbox-hover');
+                }
+            });
+            jqSelf.off('mouseleave', '.jexcel_dropdown').on('mouseleave', '.jexcel_dropdown', function() {
+                $(this).removeClass('exf-dropdown-hitbox-hover');
             });
 
             // wrap/replace the original keydown listener of JExcel, in order to overwrite the tab functionality
@@ -519,9 +529,6 @@ JS;
                 let sColumnType = instance.jexcel.options.columns[col].type;
                 if (instance.exfWidget.bLoaded && sColumnType === 'autocomplete') { 
 
-                    // re-add the hitbox for single-click
-                    instance.exfWidget.addDropdownHitboxes(cell);
-
                     // update the related cols
                     if (instance.exfWidget.getColumnModel(col).dependantCols.length > 0){
                         instance.exfWidget.updateDependantColumns(col, row, value);
@@ -536,7 +543,6 @@ JS;
             }, 0);
         },
         oninsertrow: function(el, rowNumber, numOfRows, rowTDs, insertBefore) {
-            el.exfWidget.addDropdownHitboxes();
         },
         ondeleterow: function(el, rowNumber, numOfRows, rowDOMElements, rowData, cellAttributes) {
             {$this->buildJsFixedFootersSpread()}
@@ -1270,27 +1276,6 @@ JS;
                 else {
                     console.warn('Relation key ' + sColRelationKey + ' not found in dropdown source');
                 }
-            }
-        },
-        addDropdownHitboxes: function (oCell = null) {
-            // attaches a single-click hitbox to open a dropdown editor on a cell.
-            // if a a specific cell is passed as parameter, only attach to that cell, otherwise check all dropdowns
-            var jqSelf = {$this->buildJsJqueryElement()};
-            
-            if (oCell !== null) {
-                // Attach hitbox for the specific cell
-                if (!$(oCell).find(".dropdown-open").length) {
-                    $(oCell).prepend("<i class='dropdown-open' aria-hidden='true'></i>");
-                }
- 
-            }
-            else {
-                // check for all dropdowns
-                jqSelf.find(".jexcel_dropdown").each(function(){
-                    if(!$(this).find(".dropdown-open").length) {
-                        $(this).prepend("<i class='dropdown-open' aria-hidden='true'></i>");
-                    }
-                });
             }
         },
         showAddRowsDialogue: function() {


### PR DESCRIPTION
Before, we used an invsible `<i>` element with a onclick function to open dropdown editors on single click. However, this lead to issues with frontend filtering, as the html element was shown as table content.

New approach: register onclick to dropdown cell directly. Then check by coordinates if we are in the former hitbox area (35px from right edge), if so, open editor. Styling of hitbox area is done using a pseudo :after element. (The after element itself cannot be used for the onclick interaction, since the pseudo elements are not part of the DOM)

Styling: https://github.com/ExFace/JEasyUIFacade/pull/129 , https://github.com/ExFace/UI5Facade/pull/329 