### PR TITLE
NEW: Made syncUserRoles public.

### DIFF
--- a/CommonLogic/Security/Authenticators/AbstractAuthenticator.php
+++ b/CommonLogic/Security/Authenticators/AbstractAuthenticator.php
@@ -565,7 +565,7 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface, iCanBeCo
      * @param UserInterface $user
      * @param AuthenticationTokenInterface $token
      */
-    protected function syncUserRoles(UserInterface $user, AuthenticationTokenInterface $token) : AuthenticatorInterface
+    public function syncUserRoles(UserInterface $user, AuthenticationTokenInterface $token) : AuthenticatorInterface
     {
         if ($this->hasSyncRoles() === false) {
             return $this;


### PR DESCRIPTION
Made syncUserRoles public so it can be used in microsoft365connector.SyncEntraIdRoles

Related PR: https://github.com/axenox/Microsoft365Connector/pull/23