### PR TITLE
NEW: WidgetSetups can now save/load header filters

### DIFF
--- a/Facades/AbstractAjaxFacade/Elements/JqueryDataConfiguratorTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JqueryDataConfiguratorTrait.php
@@ -41,6 +41,43 @@ trait JqueryDataConfiguratorTrait
         }
         return;
     }
+
+    /**
+     * Returns the filters of a data object, and adds a hidden flag, indicating whether the filter is hidden or not. 
+     * This only works for rendered filters, as it gets the current JS values of the filters.
+     *
+     * @return string 
+     */
+    public function buildJsFilterGetter() : string
+    {
+        $widget = $this->getWidget();
+        $filters = [];
+        $nestedGroups = [];
+
+        foreach ($widget->getFilters() as $filter) {
+            $filterElement = $this->getFacade()->getElement($filter);
+            if ($filter->hasCustomConditionGroup() === true) {
+                $nestedGroups[] = preg_replace(
+                    '/\}\s*$/',
+                    ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
+                    preg_replace('/,\s*\}\s*$/', '}', $filterElement->buildJsCustomConditionGroup())
+                );
+            } else {
+                $filters[] = preg_replace(
+                    '/\}\s*$/',
+                    ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
+                    preg_replace('/,\s*\}\s*$/', '}', $filterElement->buildJsConditionGetter(null, $widget->getMetaObject()))
+                );
+            }
+        }
+
+        $filters = array_filter($filters);
+        if (empty($filters) === false || empty($nestedGroups) === false) {
+            return '{operator: "AND", ignore_empty_values: true, conditions: [' . implode(",\n", $filters) . '], nested_groups: [' . implode(",\n", $nestedGroups) . ']}';
+        }
+
+        return '';
+    }
     
     /**
      * The data JS-object of a configurator widget contains filters, sorters, etc., that are
@@ -67,12 +104,7 @@ trait JqueryDataConfiguratorTrait
                 if ($filter->hasCustomConditionGroup() === true) {
                     $nestedGroups[] = $filterElement->buildJsCustomConditionGroup();
                 } else {
-                    // add hidden property to properly handle hidden filters in the UI5DataConfigurator/Setups
-                    $filters[] = preg_replace(
-                        '/\}\s*$/',
-                        ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
-                        preg_replace('/,\s*\}\s*$/', '}', $filterElement->buildJsConditionGetter(null, $widget->getMetaObject()))
-                    );
+                    $filters[] = $filterElement->buildJsConditionGetter(null, $widget->getMetaObject());
                 }
             }
         } else {

--- a/Facades/AbstractAjaxFacade/Elements/JqueryDataConfiguratorTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JqueryDataConfiguratorTrait.php
@@ -67,7 +67,12 @@ trait JqueryDataConfiguratorTrait
                 if ($filter->hasCustomConditionGroup() === true) {
                     $nestedGroups[] = $filterElement->buildJsCustomConditionGroup();
                 } else {
-                    $filters[] = $filterElement->buildJsConditionGetter(null, $widget->getMetaObject());
+                    // add hidden property to properly handle hidden filters in the UI5DataConfigurator/Setups
+                    $filters[] = preg_replace(
+                        '/\}\s*$/',
+                        ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
+                        preg_replace('/,\s*\}\s*$/', '}', $filterElement->buildJsConditionGetter(null, $widget->getMetaObject()))
+                    );
                 }
             }
         } else {

--- a/Facades/AbstractAjaxFacade/js/exfTools.js
+++ b/Facades/AbstractAjaxFacade/js/exfTools.js
@@ -676,6 +676,48 @@
 		 * 
 		 */
 		data: {
+			
+			/**
+			 * Compares two JSON objects for equality. (Regardless of the order of the keys in the objects)
+			 * @param {*} obj1 
+			 * @param {*} obj2 
+			 * @param {string[]} [excludeKeys] Keys to ignore during comparison
+			 * @returns {boolean}
+			 */
+			compareJSONObjects: function(obj1, obj2, excludeKeys) {
+				excludeKeys = Array.isArray(excludeKeys) ? excludeKeys : [];
+				if (obj1 === obj2) return true;
+
+				if (obj1 === null || obj2 === null) return obj1 === obj2;
+				if (typeof obj1 !== "object" || typeof obj2 !== "object") return false;
+
+				// Arrays
+				const aIsArr = Array.isArray(obj1);
+				const bIsArr = Array.isArray(obj2);
+				if (aIsArr || bIsArr) {
+					if (!aIsArr || !bIsArr || obj1.length !== obj2.length) return false;
+					for (let i = 0; i < obj1.length; i++) {
+					if (!this.compareJSONObjects(obj1[i], obj2[i], excludeKeys)) return false;
+					}
+					return true;
+				}
+
+				// Objects (ignore key order)
+				const aKeys = Object.keys(obj1).filter(function(key) {
+					return excludeKeys.indexOf(key) === -1;
+				});
+				const bKeys = Object.keys(obj2).filter(function(key) {
+					return excludeKeys.indexOf(key) === -1;
+				});
+				if (aKeys.length !== bKeys.length) return false;
+
+				for (const key of aKeys) {
+					if (!Object.prototype.hasOwnProperty.call(obj2, key)) return false;
+					if (!this.compareJSONObjects(obj1[key], obj2[key], excludeKeys)) return false;
+				}
+
+				return true;
+			},
 
 			/**
 			 * Returns TRUE if two data rows arrays contain exactly the same rows (possibly in different order)


### PR DESCRIPTION
- **JqueryConfiguratorTrait:** new Method buildJsFilterGetter(), which gets current filter configuration of datawidget and the current JS values, and adds a new 'hidden' property (whether the filter is hidden or not)
- **exfTools:** new function compareJSONObjects to compare two JSON Objects (with the option to exclude certain keys)