### PR TITLE
FIX WidgetSetups: FilterGetter should handle both RangeFilter elements

### DIFF
--- a/Facades/AbstractAjaxFacade/Elements/JqueryDataConfiguratorTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JqueryDataConfiguratorTrait.php
@@ -63,11 +63,22 @@ trait JqueryDataConfiguratorTrait
                     preg_replace('/,\s*\}\s*$/', '}', $filterElement->buildJsCustomConditionGroup())
                 );
             } else {
-                $filters[] = preg_replace(
-                    '/\}\s*$/',
-                    ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
-                    preg_replace('/,\s*\}\s*$/', '}', $filterElement->buildJsConditionGetter(null, $widget->getMetaObject()))
-                );
+                $conditionJsRaw = $filterElement->buildJsConditionGetter(null, $widget->getMetaObject());
+                if ($filter instanceof \exface\Core\Widgets\RangeFilter) {
+                    // range filters return both from and to conditions, so we need to add the hidden flag to both of them. 
+                    $conditionJs = preg_replace('/,\s*\}\s*(?=,|$)/', '}', $conditionJsRaw);
+                    $filters[] = preg_replace(
+                        '/\}\s*(?=,|$)/',
+                        ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
+                        $conditionJs
+                    );
+                } else {
+                    $filters[] = preg_replace(
+                        '/\}\s*$/',
+                        ', "hidden" : ' . $this->escapeBool($filter->isHidden() === true) . '}',
+                        preg_replace('/,\s*\}\s*$/', '}', $conditionJsRaw)
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
The buildJsConditionGetter returns both from and to conditions for Range Filters, so we need to append the extra "hidden: true/false" property to both, not just the last one. Otherwise they are not saved/loaded correctly in the widget setups