### PR TITLE
FIX Button: hidden_if not working on buttons without action

### DIFF
--- a/Widgets/Button.php
+++ b/Widgets/Button.php
@@ -822,11 +822,13 @@ class Button extends AbstractWidget implements iHaveIcon, iHaveColor, iTriggerAc
      */
     public function getHiddenIf() : ?ConditionalProperty
     {
-        // If there is a 'normal' disabled_if already, get it
+        // If there is a 'normal' hidden_if already, get it
         $ownProperty = parent::getHiddenIf();
 
         // Otherwise see if we can generate one from the action
-        if (! $this->hasAction()) {
+        if (! $this->hasAction() && $ownProperty === null) {
+            // only return null here if there is no 'normal' hidden_if 
+            // otherwise hidden_ifs on buttons without actions (for example MenuButtons) do not work anymore
             return null;
         }
 


### PR DESCRIPTION
Normal hidden_ifs did not work anymore on buttons that have no action, for example on MenuButtons (the parent button)