### PR TITLE
FIX WidgetSetups: empty favourite star sometimes missing

### DIFF
--- a/Model/exface.Core.WIDGET_SETUP_USER/04_ATTRIBUTE.json
+++ b/Model/exface.Core.WIDGET_SETUP_USER/04_ATTRIBUTE.json
@@ -239,9 +239,9 @@
         {
             "_EXPORT_SUMMARY": "Favorite [FAVORITE_FLAG]",
             "CREATED_ON": "2025-06-27 09:42:23",
-            "MODIFIED_ON": "2025-06-30 12:28:05",
+            "MODIFIED_ON": "2026-06-29 15:36:17",
             "CREATED_BY_USER": "0x31000000000000000000000000000000",
-            "MODIFIED_BY_USER": "0x31000000000000000000000000000000",
+            "MODIFIED_BY_USER": "0x11e8fe1c902c8ebea23ee4b318306b9a",
             "UID": "0x11f0a6a843896914a6a8025041000001",
             "SORTABLEFLAG": 1,
             "FILTERABLEFLAG": 1,
@@ -256,6 +256,7 @@
             "DELETE_WITH_RELATED_OBJECT": 0,
             "DEFAULT_DISPLAY_UXON": {
                 "widget_type": "Icon",
+                "empty_icon": "star-o",
                 "icon_scale": [
                     "star-o",
                     "star"
@@ -266,9 +267,9 @@
             "RELATION_CARDINALITY": "",
             "TYPE": "D",
             "COPYABLEFLAG": 1,
-            "ICON": null,
-            "ICON_SET": null,
-            "ABBREVIATION": null,
+            "ICON": "",
+            "ICON_SET": "",
+            "ABBREVIATION": "",
             "ALIAS": "FAVORITE_FLAG",
             "DATATYPE": "0x37000000000000000000000000000000",
             "DATA_ADDRESS": "favorite_flag",


### PR DESCRIPTION
if there was no user entry (value null), the empty star (value 0) didnt show in the setups table