### PR TITLE
FIX DataSpreadSheet: throw explicit warning that last row cannot be deleted

### DIFF
--- a/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
+++ b/Facades/AbstractAjaxFacade/Elements/JExcelTrait.php
@@ -348,6 +348,7 @@ JS;
         allowDeleteRow: $allowDeleteRow,
         wordWrap: $wordWrap,
         tableOverflow: {$autoColumnWidth},
+        allowDeletingAllRows: true, 
         {$this->buildJsJExcelColumns()}
         {$this->buildJsJExcelMinSpareRows()}
         text:{
@@ -823,6 +824,27 @@ JS;
             }, 0);
         },
         oninsertrow: function(el, rowNumber, numOfRows, rowTDs, insertBefore) {
+        },
+        onbeforedeleterow: function(el, rowNumber, numOfRows, rowDOMElements, rowData, cellAttributes) {
+            // deleting the last row isnt allowed within Jexcel (by default), because otherwise the users have no way
+            // of adding new rows again. see https://github.com/jspreadsheet/ce/issues/1244
+            // Usually this fails slilently (JS console error), but normal user cant see those
+            // as a workaround, we allow it programatically, (allowDeletingAllRows: true), 
+            // so we can throw an explicit alert here (and return false to cancel the deletion)
+            
+            var aAllRows = (el && el.jexcel && typeof el.jexcel.getData === 'function') ? (el.jexcel.getData() || []) : [];
+            var bIsDeletingAllMultiselect = (aAllRows.length === numOfRows) && aAllRows.length > 1;
+            if ((aAllRows.length === 1 && rowNumber === 0) || bIsDeletingAllMultiselect) {
+                window.alert('{$translator->translate('WIDGET.JEXCEL.CANNOT_DELETE_LAST_ROW')}');
+
+                if (bIsDeletingAllMultiselect){
+                    // if we have all/multiple rows selected, the default behaviour would be to delete all except hte last row
+                    // so we try and recreate that by removing all rows except the last one here 
+                   el.jexcel.setData([aAllRows[aAllRows.length - 1] || []]); 
+                }
+
+                return false;
+            }
         },
         ondeleterow: function(el, rowNumber, numOfRows, rowDOMElements, rowData, cellAttributes) {
             {$this->buildJsFixedFootersSpread()}

--- a/Translations/exface.Core.de.json
+++ b/Translations/exface.Core.de.json
@@ -456,6 +456,7 @@
     "WIDGET.JEXCEL.PASTE": "Einfügen ...",
     "WIDGET.JEXCEL.SAVE_AS": "Speichern als ...",
     "WIDGET.JEXCEL.CONFIRM_DELETE_ROWS": "Sind Sie sicher, dass Sie die ausgewählten Zeilen löschen möchten?",
+    "WIDGET.JEXCEL.CANNOT_DELETE_LAST_ROW": "Die letzte Zeile kann nicht gelöscht werden.",
     "WIDGET.JEXCEL.CONFIRM_DELETE_COLUMNS": "Sind Sie sicher, dass Sie die ausgewählten Spalten löschen möchten?",
     "WIDGET.JEXCEL.CONFIRM_DESTROY_MERGED_CELLS": "Diese Aktion wird alle vorhandenen verbundenen Zellen zerstören. Sind Sie sicher?",
     "WIDGET.JEXCEL.CONFIRM_CLEAR_SEARCH": "Diese Aktion wird Ihre Suchergebnisse löschen. Sind Sie sicher?",

--- a/Translations/exface.Core.en.json
+++ b/Translations/exface.Core.en.json
@@ -470,6 +470,7 @@
     "WIDGET.JEXCEL.PASTE": "Paste ...",
     "WIDGET.JEXCEL.SAVE_AS": "Save as ...",
     "WIDGET.JEXCEL.CONFIRM_DELETE_ROWS": "Are you sure you want to delete the selected rows?",
+    "WIDGET.JEXCEL.CANNOT_DELETE_LAST_ROW": "Cannot delete the last row.",
     "WIDGET.JEXCEL.CONFIRM_DELETE_COLUMNS": "Are you sure you want to delete the selected columns?",
     "WIDGET.JEXCEL.CONFIRM_DESTROY_MERGED_CELLS": "This action will destroy any existing merged cells. Are you sure?",
     "WIDGET.JEXCEL.CONFIRM_CLEAR_SEARCH": "This action will clear your search results. Are you sure?",


### PR DESCRIPTION
- give explicit window alert to user, instead of just failing silently 