### PR TITLE
FIX Revert changes from e7922c033938ef4cd0baa67a2c9ec88f9b84bc1e

### DIFF
--- a/CommonLogic/DataSheets/DataSheet.php
+++ b/CommonLogic/DataSheets/DataSheet.php
@@ -1160,19 +1160,12 @@ class DataSheet implements DataSheetInterface
         
         // Filter the nested data using filters from the parent sheet if
         // - condition is not empty
-        // - AND (
-        //  - condition is based on the nested object (e.g. special filters, that are explicitly based not on the object
-        //  of their data widget)
-        //  - OR (
-        //      - condition has a relation path, and it starts with the relation to the nested sheet
-        //      - AND condition has `apply_to_aggregates` set to TRUE
-        //  )
-        // )
+        // - condition has a relation path, and it starts with the relation to the nested sheet
+        // - condition has `apply_to_aggregates` set to TRUE
         // IDEA should we somehow make this configurable? It is hard for the designer to understand, which filters
         // will apply to nested data and which won't
         // NOTE: right now only level-1 conditions are applied - no nested condition groups. It is unclear, how
-        // to apply nested groups reliably as they might include conditions, that cannot be rebased.
-        $nestedObj = $nestedSheet->getMetaObject();
+        // to apply nested groups relyably as they might include conditions, that cannot be rebased.
         foreach ($this->getFilters()->getConditions() as $cond) {
             if ($cond->isEmpty()) {
                 continue;
@@ -1182,26 +1175,17 @@ class DataSheet implements DataSheetInterface
                 continue;
             }
             $condAttr = $condExpr->getAttribute();
-            switch (true) {
-                // If the condition is already based on the object of the nested data, use it as-is
-                case $nestedObj->is($condExpr->getMetaObject()):
-                    $nestedSheet->getFilters()->addCondition($cond);
-                    break;
-                // If the condition has a relation and that relation "goes through" the object of the nested data,
-                // rebase it and use it
-                case $condAttr->isRelated()
+            if (
+                $condAttr->isRelated()
                 && $condAttr->getRelationPath()->startsWith($relPathToNestedSheet)
-                && $cond->willApplyToAggregatedValues():
-                    try {
-                        $nestedCond = $cond->rebase($relPathToNestedSheet);
-                        $nestedSheet->getFilters()->addCondition($nestedCond);
-                    } catch (ExpressionRebaseImpossibleError $e) {
-                        continue 2;
-                    }
-                    break;
-                // Ignore any other conditions
-                default:
-                    continue 2;
+                && $cond->willApplyToAggregatedValues()
+            ) {
+                try {
+                    $nestedCond = $cond->rebase($relPathToNestedSheet);
+                    $nestedSheet->getFilters()->addCondition($nestedCond);
+                } catch (ExpressionRebaseImpossibleError $e) {
+                    continue;
+                }
             }
         }
         

--- a/CommonLogic/QueryBuilder/QueryPartFilterGroup.php
+++ b/CommonLogic/QueryBuilder/QueryPartFilterGroup.php
@@ -148,12 +148,7 @@ class QueryPartFilterGroup extends QueryPart implements iCanBeCopied
     {
         $qpart = new QueryPartFilterGroup('', $query, $parentQueryPart);
         $qpart->setOperator($group->getOperator());
-        $queryObj = $query->getMainObject();
         foreach ($group->getConditions() as $c) {
-            $conditionObj = $c->getExpression()->getMetaObject();
-            if ($conditionObj !== null && ! $queryObj->is($conditionObj)) {
-                continue;
-            }
             $qpart->addCondition($c);
         }
         foreach ($group->getNestedGroups() as $g) {


### PR DESCRIPTION
These changes did break the prefill of dialogs that are based on one object but are opened from widget based on a different object. Also the commit message did not reflect that those changes are included, it seemed like they were commited by accident