### PR TITLE
Fix/sync mail flag default 0 to 1 migrations

### DIFF
--- a/Install/Sql/MsSQL/Migrations/1.41/20260807_1120_1_FIX_exf_user_authenticator_sync_mail_flag_default_0_to_1.sql
+++ b/Install/Sql/MsSQL/Migrations/1.41/20260807_1120_1_FIX_exf_user_authenticator_sync_mail_flag_default_0_to_1.sql
@@ -1,0 +1,24 @@
+/*
+ * Changes the default value of the sync_mail_flag column in the exf_user_authenticator table from 0 to 1.
+ *
+ * @author Sergej Riel
+ */
+-- UP
+ALTER TABLE exf_user_authenticator
+DROP CONSTRAINT DF_exf_user_authenticator_sync_mail_flag;
+GO
+
+ALTER TABLE exf_user_authenticator
+ADD CONSTRAINT DF_exf_user_authenticator_sync_mail_flag
+    DEFAULT (1) FOR sync_mail_flag;
+GO
+
+-- DOWN
+ALTER TABLE exf_user_authenticator
+DROP CONSTRAINT DF_exf_user_authenticator_sync_mail_flag;
+GO
+
+ALTER TABLE exf_user_authenticator
+ADD CONSTRAINT DF_exf_user_authenticator_sync_mail_flag
+    DEFAULT (0) FOR sync_mail_flag;
+GO

--- a/Install/Sql/MySQL/Migrations/1.41/20260807_1200_1_FIX_exf_user_authenticator_sync_mail_flag_default_0_to_1.sql
+++ b/Install/Sql/MySQL/Migrations/1.41/20260807_1200_1_FIX_exf_user_authenticator_sync_mail_flag_default_0_to_1.sql
@@ -1,0 +1,10 @@
+/*
+ * Changes the default value of the sync_mail_flag column in the exf_user_authenticator table from 0 to 1.
+ *
+ * @author Sergej Riel
+ */
+-- UP
+    ALTER TABLE exf_user_authenticator ALTER COLUMN sync_mail_flag SET DEFAULT 1
+
+-- DOWN
+    ALTER TABLE exf_user_authenticator ALTER COLUMN sync_mail_flag SET DEFAULT 0

--- a/Install/Sql/PostgreSQL/Migrations/1.41/20260807_1120_1_FIX_exf_user_authenticator_sync_mail_flag_default_0_to_1.sql
+++ b/Install/Sql/PostgreSQL/Migrations/1.41/20260807_1120_1_FIX_exf_user_authenticator_sync_mail_flag_default_0_to_1.sql
@@ -1,0 +1,10 @@
+/*
+ * Changes the default value of the sync_mail_flag column in the exf_user_authenticator table from 0 to 1.
+ *
+ * @author Sergej Riel
+ */
+-- UP
+ALTER TABLE exf_user_authenticator ALTER COLUMN sync_mail_flag SET DEFAULT 1
+
+-- DOWN
+ALTER TABLE exf_user_authenticator ALTER COLUMN sync_mail_flag SET DEFAULT 0


### PR DESCRIPTION
FIX: Migration that changes the default value of the sync_mail_flag column in the exf_user_authenticator table from 0 to 1.