### PR TITLE
NEW DisplayTemplate: render_as_formatted_text for improved performance

### DIFF
--- a/Widgets/DisplayTemplate.php
+++ b/Widgets/DisplayTemplate.php
@@ -1,37 +1,22 @@
 <?php
 namespace exface\Core\Widgets;
 
-use exface\Core\CommonLogic\Model\RelationPath;
 use exface\Core\DataTypes\StringDataType;
-use exface\Core\Factories\RelationPathFactory;
-use exface\Core\Interfaces\Model\MetaRelationPathInterface;
-use exface\Core\Interfaces\Widgets\iCanBeBoundToCalculation;
 use exface\Core\Interfaces\Widgets\iShowSingleAttribute;
 use exface\Core\Interfaces\Widgets\iHaveValue;
 use exface\Core\Interfaces\DataSheets\DataSheetInterface;
 use exface\Core\Factories\DataTypeFactory;
-use exface\Core\Exceptions\Widgets\WidgetPropertyInvalidValueError;
-use exface\Core\Factories\DataSheetFactory;
 use exface\Core\Interfaces\DataTypes\DataTypeInterface;
-use exface\Core\CommonLogic\Model\Aggregator;
-use exface\Core\Interfaces\Model\AggregatorInterface;
-use exface\Core\Interfaces\Widgets\iSupportAggregators;
 use exface\Core\Exceptions\Widgets\WidgetConfigurationError;
-use exface\Core\CommonLogic\DataSheets\DataAggregation;
-use exface\Core\Factories\ExpressionFactory;
 use exface\Core\Interfaces\Widgets\iHaveMultipleBindings;
 use exface\Core\Interfaces\Widgets\iShowDataColumn;
 use exface\Core\Widgets\Parts\WidgetPropertyBinding;
 use exface\Core\Widgets\Traits\AttributeCaptionTrait;
 use exface\Core\CommonLogic\Model\Expression;
-use exface\Core\DataTypes\EncryptedDataType;
 use exface\Core\Interfaces\Model\ExpressionInterface;
 use exface\Core\Interfaces\Widgets\WidgetLinkInterface;
 use exface\Core\Interfaces\Model\MetaAttributeInterface;
-use exface\Core\Widgets\Traits\iHaveAttributeGroupTrait;
-use exface\Core\Widgets\Traits\PrefillValueTrait;
 use exface\Core\CommonLogic\UxonObject;
-use exface\Core\CommonLogic\DataSheets\DataColumn;
 
 /**
  * HTML or text template with placeholders replaced by values from a data row

--- a/Widgets/DisplayTemplate.php
+++ b/Widgets/DisplayTemplate.php
@@ -41,6 +41,13 @@ use exface\Core\CommonLogic\UxonObject;
  *
  * When used inside of data widget cells, this widget will make the Facade load all attributes required for the 
  * template and place them in the server data.
+ * 
+ * ## Rendering as formatted text
+ * 
+ * For UI5 tables, you can set `render_as_formatted_text` to render the template via `sap.m.FormattedText`
+ * instead of `sap.ui.core.HTML`. This typically improves scroll performance because the control is lighter.
+ * 
+ * `sap.m.FormattedText` supports only a safe subset of HTML. If the template depends on complex layout markup or unsupported tags, keep this option disabled.
  *
  * ## Placeholders
  *
@@ -62,6 +69,7 @@ class DisplayTemplate extends AbstractWidget implements iShowSingleAttribute, iH
     private ?string $template = null;
     private ?string $emptyText = null;
     private ?array $bindings = null;
+    private bool $render_as_formatted_text = false;
     
     public function getTemplate() : string
     {
@@ -257,6 +265,66 @@ class DisplayTemplate extends AbstractWidget implements iShowSingleAttribute, iH
         $uxon = parent::exportUxonObject();
         $uxon->setProperty('template', $this->getTemplate());
         return $uxon;
+    }
+
+    /**
+     * Returns TRUE if the template should be rendered as `sap.m.FormattedText` where supported.
+     *
+     * @return bool
+     */
+    public function getRenderAsFormattedText() : bool
+    {
+        return $this->render_as_formatted_text;
+    }
+
+    /**
+     * Set to TRUE to render this template as `sap.m.FormattedText` in UI5 table cells.
+     * 
+     * This can improve performance in large tables compared to `sap.ui.core.HTML`, but only
+     * a limited/safe subset of HTML is supported by `sap.m.FormattedText`.
+     * 
+    * Text in HTML format. The following tags are supported:
+    * 
+    * - `a`
+    * - `abbr`
+    * - `bdi`
+    * - `blockquote`
+    * - `br`
+    * - `cite`
+    * - `code`
+    * - `em`
+    * - `h1`
+    * - `h2`
+    * - `h3`
+    * - `h4`
+    * - `h5`
+    * - `h6`
+    * - `p`
+    * - `pre`
+    * - `strong`
+    * - `span`
+    * - `u`
+    * - `s`
+    * - `dl`
+    * - `dt`
+    * - `dd`
+    * - `ul`
+    * - `ol`
+    * - `li`
+    * 
+    * `style`, `dir` and `target` attributes are allowed.
+     * 
+     * @uxon-property render_as_formatted_text
+     * @uxon-type boolean
+     * @uxon-default false
+     * 
+     * @param bool $value
+     * @return DisplayTemplate
+     */
+    public function setRenderAsFormattedText(bool $value) : DisplayTemplate
+    {
+        $this->render_as_formatted_text = $value;
+        return $this;
     }
     
     /**


### PR DESCRIPTION
New option render_as_formatted_text, to improve performance. Replacing the core.HTML in tables (for example when scrolling) is very expensive and can cause lagging in tables with many cells that use the template. The sap formatted text is more lightweight, but only supports a subset of html tags 