### PR TITLE
Feature/frappe to riel gantt migration

### DIFF
--- a/Widgets/Parts/DataTimeline.php
+++ b/Widgets/Parts/DataTimeline.php
@@ -172,6 +172,9 @@ class DataTimeline implements WidgetPartInterface
     const INTERVAL_MONTH = 'month';
     const INTERVAL_YEAR = 'year';
     const INTERVAL_DECADE = 'decade';
+
+    const POPUP_ON_CLICK = 'click';
+    const POPUP_ON_HOVER = 'hover';
     
     private ?array $views = null;
     private ?UxonObject $viewsUxon = null;
@@ -181,6 +184,7 @@ class DataTimeline implements WidgetPartInterface
     private bool $row_zoom = false;
     private $workday_start_time = null;
     private $workday_end_time = null;
+    private ?string $popup_on = null;
     
     public function exportUxonObject()
     {
@@ -274,6 +278,42 @@ class DataTimeline implements WidgetPartInterface
     public function getRowZoom() : bool
     {
         return $this->row_zoom;
+    }
+
+    /**
+     * @param string|null $default
+     * @return string|null
+     */
+    public function getPopupOn(string $default = null) : ?string
+    {
+        return $this->popup_on ?? $default;
+    }
+
+    /**
+     * Define whether timeline item popups open on click or hover.
+     * In Gantt behavior:
+     * - `click` - user has to click on the bar to open the popup and click outside to close it.
+     * - `hover` - hovering shows the popup and leaving the bar hides it; clicking a bar pins the popup until the user clicks outside a bar or clicks another bar.
+     * 
+     * ATTENTION: The "hover" option is @experimental. Do not use it in production yet!
+     *
+     * @uxon-property popup_on
+     * @uxon-type [click,hover]
+     *
+     * @param string $value
+     * @return DataTimeline
+     */
+    public function setPopupOn(string $value) : DataTimeline
+    {
+        $value = mb_strtolower($value);
+        switch ($value) {
+            case self::POPUP_ON_CLICK:
+            case self::POPUP_ON_HOVER:
+                $this->popup_on = $value;
+                return $this;
+        }
+
+        throw new WidgetConfigurationError($this->getWidget(), 'Invalid timeline popup_on value "' . $value . '": please use click or hover!');
     }
     
     /**

--- a/Widgets/Parts/DataTimeline.php
+++ b/Widgets/Parts/DataTimeline.php
@@ -367,7 +367,6 @@ class DataTimeline implements WidgetPartInterface
             if ($this->viewsUxon === null) {
                 $translator = $this->getWorkbench()->getCoreApp()->getTranslator();
                 // IDEA get defaults from widget? Different defaults for Gantt and Scheduler?
-                // Info: This defaults are similar to frappe-gantt defaults.
                 $this->views = [
                     new DataTimelineView($this, new UxonObject([
                         'name' => $translator->translate('WIDGET.GANTT_CHARD.VIEW_MODE_DAY'),

--- a/Widgets/Parts/DataTimelineHeader.php
+++ b/Widgets/Parts/DataTimelineHeader.php
@@ -17,7 +17,7 @@ use exface\Core\Interfaces\Widgets\WidgetPartInterface;
  * 
  * ## Examples
  * 
- * In frappe-gantt, to show a timeline with months at the top and days below:
+ * In Gantt, to show a timeline with months at the top and days below:
  * ```
  *      "header_lines": [
  *          {

--- a/Widgets/Parts/DataTimelineView.php
+++ b/Widgets/Parts/DataTimelineView.php
@@ -217,7 +217,7 @@ class DataTimelineView implements WidgetPartInterface, iHaveIcon
     
     /**
      * Sets the padding of the timeline view.
-     * In frappe-gantt, this is the extra space before the start of the first task and after the end date of the last task inside the timeline.
+     * In Gantt, this is the extra space before the start of the first task and after the end date of the last task inside the timeline.
      * Examples: 
      * - "7d" adds 7 days of padding on both sides.
      * - "1m" adds 1 month of padding on both sides.
@@ -245,7 +245,7 @@ class DataTimelineView implements WidgetPartInterface, iHaveIcon
     
     /**
      * Sets the snap_at of the timeline view.
-     * In frappe-gantt, this defines the snapping behavior when dragging tasks.
+     * In Gantt, this defines the snapping behavior when dragging tasks.
      * Possible values:
      * - "daily" (snaps to each day)
      * - "weekly" (snaps to each week)
@@ -273,7 +273,7 @@ class DataTimelineView implements WidgetPartInterface, iHaveIcon
     
     /**
      * Sets the upper_text_frequency of the timeline view.
-     * In frappe-gantt, this defines how often the upper header text is displayed.
+     * In Gantt, this defines how often the upper header text is displayed.
      * For example, a value of 4 means the upper header text is shown every 4 units of the granularity.
      * 
      * @uxon-property upper_text_frequency


### PR DESCRIPTION
REF: removed the name "frappe-gantt" from docs.

NEW: @experimental feature: popup_on Uxon property. Values:
 - `click` - user has to click on the bar to open the popup and click outside to close it.
 - `hover` - hovering shows the popup and leaving the bar hides it; clicking a bar pins the popup until the user clicks outside a bar or clicks another bar.

ATTENTION: The "hover" option is @experimental. Do not use it in production yet!

Corresponding PR: https://github.com/ExFace/UI5Facade/pull/416